### PR TITLE
[bugfix] fix inflightRequestLock deadlock in tcp/udp tracing

### DIFF
--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -264,7 +264,7 @@ func (t *TCPTracer) send(ttl int) error {
 		return err
 	}
 	t.inflightRequestLock.Lock()
-	hopCh := make(chan Hop)
+	hopCh := make(chan Hop, 1)
 	t.inflightRequest[int(sequenceNumber)] = hopCh
 	t.inflightRequestLock.Unlock()
 	/*

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -251,7 +251,7 @@ func (t *TCPTracerv6) send(ttl int) error {
 	}
 	// log.Println(ttl, sequenceNumber)
 	t.inflightRequestLock.Lock()
-	hopCh := make(chan Hop)
+	hopCh := make(chan Hop, 1)
 	t.inflightRequest[int(sequenceNumber)] = hopCh
 	t.inflightRequestLock.Unlock()
 

--- a/trace/udp.go
+++ b/trace/udp.go
@@ -225,7 +225,7 @@ func (t *UDPTracer) send(ttl int) error {
 
 	// 在对inflightRequest进行写操作的时候应该加锁保护，以免多个goroutine协程试图同时写入造成panic
 	t.inflightRequestLock.Lock()
-	hopCh := make(chan Hop)
+	hopCh := make(chan Hop, 1)
 	t.inflightRequest[srcPort] = hopCh
 	t.inflightRequestLock.Unlock()
 	defer func() {


### PR DESCRIPTION
take ipv4 tcp tracer as an example:
In tracer/tcp_ipv4, TCPTracer.send() make a channel without buffer which is used to receive the result hop.
![image](https://github.com/user-attachments/assets/f89bf95d-cce1-4a3e-89b0-e8174266bb09)
However, when send() is timeout, the func returns. So there will be no receivers to receive the channel, which causes the channel blocked forever.
![image](https://github.com/user-attachments/assets/8c2dc66b-623b-457a-b432-1229ac765bb4)

The result hop sended to the channel after timeout will block forever too. And the inflightRequestLock never unlocks, causing all the send() goroutines blocked forever and the waitgroup will never done. Then, deadlock.
![image](https://github.com/user-attachments/assets/095f87b0-80f8-4bc5-a56c-a2d405dcd4d5)

The same thing occurs in ipv6 tcp and udp tracer too.

This bugfix makes the channel with 1 buffer, which can avoid the send block.
