### PR TITLE
use fixed source ports for TCP and UDP mode, customization supported

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -57,12 +57,13 @@ func Excute() {
 	disableMaptrace := parser.Flag("M", "map", &argparse.Options{Help: "Disable Print Trace Map"})
 	disableMPLS := parser.Flag("e", "disable-mpls", &argparse.Options{Help: "Disable MPLS"})
 	ver := parser.Flag("v", "version", &argparse.Options{Help: "Print version info and exit"})
-	srcAddr := parser.String("s", "source", &argparse.Options{Help: "Use source src_addr for outgoing packets"})
+	srcAddr := parser.String("s", "source", &argparse.Options{Help: "Use source address src_addr for outgoing packets"})
+	srcPort := parser.Int("", "source-port", &argparse.Options{Help: "Use source port src_port for outgoing packets (TCP and UDP only)"})
 	srcDev := parser.String("D", "dev", &argparse.Options{Help: "Use the following Network Devices as the source address in outgoing packets"})
 	//router := parser.Flag("R", "route", &argparse.Options{Help: "Show Routing Table [Provided By BGP.Tools]"})
-	packetInterval := parser.Int("z", "send-time", &argparse.Options{Default: 50, Help: "Set how many [milliseconds] between sending each packet.. Useful when some routers use rate-limit for ICMP messages"})
+	packetInterval := parser.Int("z", "send-time", &argparse.Options{Default: 50, Help: "Set how many [milliseconds] between sending each packet. Useful when some routers use rate-limit for ICMP messages"})
 	ttlInterval := parser.Int("i", "ttl-time", &argparse.Options{Default: 50, Help: "Set how many [milliseconds] between sending packets groups by TTL. Useful when some routers use rate-limit for ICMP messages"})
-	timeout := parser.Int("", "timeout", &argparse.Options{Default: 1000, Help: "The number of [milliseconds] to keep probe sockets open before giving up on the connection."})
+	timeout := parser.Int("", "timeout", &argparse.Options{Default: 1000, Help: "The number of [milliseconds] to keep probe sockets open before giving up on the connection"})
 	packetSize := parser.Int("", "psize", &argparse.Options{Default: 52, Help: "Set the payload size"})
 	str := parser.StringPositional(&argparse.Options{Help: "IP Address or domain name"})
 	dot := parser.Selector("", "dot-server", []string{"dnssb", "aliyun", "dnspod", "google", "cloudflare"}, &argparse.Options{
@@ -260,6 +261,7 @@ func Excute() {
 	var conf = trace.Config{
 		DN42:             *dn42,
 		SrcAddr:          *srcAddr,
+		SrcPort:          *srcPort,
 		BeginHop:         *beginHop,
 		DestIP:           ip,
 		DestPort:         *port,

--- a/trace/tcp_ipv4.go
+++ b/trace/tcp_ipv4.go
@@ -211,7 +211,12 @@ func (t *TCPTracer) send(ttl int) error {
 	}
 	// 随机种子
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	_, srcPort := util.LocalIPPort(t.DestIP)
+	if !t.SrcPortSet {
+		if t.SrcPort == 0 {
+			_, t.SrcPort = util.LocalIPPort(t.DestIP)
+		}
+		t.SrcPortSet = true
+	}
 	ipHeader := &layers.IPv4{
 		SrcIP:    t.SrcIP,
 		DstIP:    t.DestIP,
@@ -225,7 +230,7 @@ func (t *TCPTracer) send(ttl int) error {
 	// 使用Uint16兼容32位系统，防止在rand的时候因使用int32而溢出
 	sequenceNumber := uint32(r.Intn(math.MaxUint16))
 	tcpHeader := &layers.TCP{
-		SrcPort: layers.TCPPort(srcPort),
+		SrcPort: layers.TCPPort(t.SrcPort),
 		DstPort: layers.TCPPort(t.DestPort),
 		Seq:     sequenceNumber,
 		SYN:     true,

--- a/trace/tcp_ipv6.go
+++ b/trace/tcp_ipv6.go
@@ -200,7 +200,12 @@ func (t *TCPTracerv6) send(ttl int) error {
 	}
 	// 随机种子
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	_, srcPort := util.LocalIPPortv6(t.DestIP)
+	if !t.SrcPortSet {
+		if t.SrcPort == 0 {
+			_, t.SrcPort = util.LocalIPPortv6(t.DestIP)
+		}
+		t.SrcPortSet = true
+	}
 	ipHeader := &layers.IPv6{
 		SrcIP:      t.SrcIP,
 		DstIP:      t.DestIP,
@@ -211,7 +216,7 @@ func (t *TCPTracerv6) send(ttl int) error {
 	sequenceNumber := uint32(r.Intn(math.MaxUint16))
 
 	tcpHeader := &layers.TCP{
-		SrcPort: layers.TCPPort(srcPort),
+		SrcPort: layers.TCPPort(t.SrcPort),
 		DstPort: layers.TCPPort(t.DestPort),
 		Seq:     sequenceNumber,
 		SYN:     true,

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -23,6 +23,7 @@ var (
 
 type Config struct {
 	SrcAddr          string
+	SrcPort          int
 	BeginHop         int
 	MaxHops          int
 	NumMeasurements  int
@@ -32,6 +33,7 @@ type Config struct {
 	DestPort         int
 	Quic             bool
 	IPGeoSource      ipgeo.Source
+	SrcPortSet       bool
 	RDns             bool
 	AlwaysWaitRDNS   bool
 	PacketInterval   int


### PR DESCRIPTION
1. NextTrace now defaults to using a fixed random source port (in TCP and UDP mode).
2. The source port used can be customized via the “--source-port” parameter.
3. In UDP mode, the use of a fixed source port has been roughly implemented, but further improvements are still needed in the future.