### PR TITLE
更新 README 和 README_zh_CN 文件，添加 Debian/Ubuntu 的自动安装说明及相关命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,16 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
     - Supports: `amd64`, `i386`, `arm64`, `armel`, `armhf`, `loong64`, `mipsel`, `mips64el`, `ppc64el`, `riscv64`, `s390x`
     - Add the repository and install:
       ```shell
-      curl -fsSL https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg | sudo tee /etc/apt/keyrings/nexttrace.gpg >/dev/null
-      echo "Types: deb
-      URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
-      Suites: ./
-      Signed-By: /etc/apt/keyrings/nexttrace.gpg" | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
+      sudo install -d -m 0755 /etc/apt/keyrings
+      curl -fsSL -o /tmp/nexttrace-archive-keyring.gpg https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg
+      sudo install -m 0644 /tmp/nexttrace-archive-keyring.gpg /etc/apt/keyrings/nexttrace.gpg
+      rm -f /tmp/nexttrace-archive-keyring.gpg
+      sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null <<'EOF'
+Types: deb
+URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
+Suites: ./
+Signed-By: /etc/apt/keyrings/nexttrace.gpg
+EOF
       sudo apt update
       sudo apt install nexttrace
       ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
 - Debian / Ubuntu
   - Recommended: install from the official `nexttrace-debs` APT repository
     - Supports: `amd64`, `i386`, `arm64`, `armel`, `armhf`, `loong64`, `mipsel`, `mips64el`, `ppc64el`, `riscv64`, `s390x`
-    - Add the repository and install:
+    - Add the repository and install the default package:
       ```shell
       sudo install -d -m 0755 /etc/apt/keyrings
       curl -fsSL -o /tmp/nexttrace-archive-keyring.gpg https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg
@@ -68,9 +68,8 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
       sudo apt update
       sudo apt install nexttrace
       ```
-    - Install a flavor (choose one):
+    - Optionally install additional flavors:
       ```shell
-      sudo apt install nexttrace
       sudo apt install nexttrace-tiny
       sudo apt install ntr
       ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
       sudo apt update
       sudo apt install nexttrace
       ```
-    - Install a specific flavor:
+    - Install a flavor (choose one):
       ```shell
       sudo apt install nexttrace
       sudo apt install nexttrace-tiny
@@ -162,7 +162,7 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
 Please note:
 
 - The `nexttrace-debs` APT repository is maintained by nxtrace and wcbing.
-- Other package sources above are maintained by open source enthusiasts. Availability and timely updates are not guaranteed. If you encounter problems, please contact the repository maintainer to solve them, or use the binary packages provided by the official build of this project.
+- Other package sources above are maintained by open-source enthusiasts. Availability and timely updates are not guaranteed. If you encounter problems, please contact the repository maintainer to solve them, or use the binary packages provided by the official build of this project.
 
 ### Manual Install
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
 
 ### Automated Install
 
+- Debian / Ubuntu
+  - Recommended: install from the official `nexttrace-debs` APT repository
+    - Supports: `amd64`, `i386`, `arm64`, `armel`, `armhf`, `loong64`, `mipsel`, `mips64el`, `ppc64el`, `riscv64`, `s390x`
+    - Add the repository and install:
+      ```shell
+      curl -fsSL https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg | sudo tee /etc/apt/keyrings/nexttrace.gpg >/dev/null
+      echo "Types: deb
+      URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
+      Suites: ./
+      Signed-By: /etc/apt/keyrings/nexttrace.gpg" | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
+      sudo apt update
+      sudo apt install nexttrace
+      ```
+    - Install a specific flavor:
+      ```shell
+      sudo apt install nexttrace
+      sudo apt install nexttrace-tiny
+      sudo apt install ntr
+      ```
+    - Packages can be installed side by side. Commands: `nexttrace`, `nexttrace-tiny`, `ntr`
+
 - Linux / macOS / BSD
   - One-click installation script (Full, default)
 
@@ -74,23 +95,7 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
     curl -sL https://nxtrace.org/nt | bash -s -- --flavor ntr
     ```
 
-  - Installed command names:
-    - Full: `nexttrace`
-    - Tiny: `nexttrace-tiny`
-    - NTR: `ntr`
-
-  - Install nxtrace from the APT repository
-    - Supports AMD64/ARM64 architectures
-      ```shell
-      curl -fsSL https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg | sudo tee /etc/apt/keyrings/nexttrace.gpg >/dev/null
-      echo "Types: deb
-      URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
-      Suites: ./
-      Signed-By: /etc/apt/keyrings/nexttrace.gpg" | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
-      sudo apt update
-      sudo apt install nexttrace
-      ```
-    - APT repository maintained by wcbing and nxtrace
+  - Installed command names: Full `nexttrace`, Tiny `nexttrace-tiny`, NTR `ntr`
 
   - Arch Linux AUR installation command
     - Directly download bin package (only supports amd64)
@@ -154,7 +159,10 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
       ```
     - Scoop-extra is maintained by soenggam
 
-Please note, the repositories for all of the above installation methods are maintained by open source enthusiasts. Availability and timely updates are not guaranteed. If you encounter problems, please contact the repository maintainer to solve them, or use the binary packages provided by the official build of this project.
+Please note:
+
+- The `nexttrace-debs` APT repository is maintained by nxtrace and wcbing.
+- Other package sources above are maintained by open source enthusiasts. Availability and timely updates are not guaranteed. If you encounter problems, please contact the repository maintainer to solve them, or use the binary packages provided by the official build of this project.
 
 ### Manual Install
 
@@ -182,7 +190,7 @@ Starting from this release, NextTrace is published in **three flavors** under th
 | Default mode          |     traceroute     |    traceroute    |   MTR TUI    |
 | Binary name           |    `nexttrace`     | `nexttrace-tiny` |    `ntr`     |
 
-> **Note:** Package managers (Homebrew, AUR, Scoop, etc.) currently install the **Full** (`nexttrace`) version only.
+> **Note:** `APT (nexttrace-debs)` provides all three flavors: **Full** (`nexttrace`), **Tiny** (`nexttrace-tiny`), and **NTR** (`ntr`). Other package managers (Homebrew, AUR, Scoop, etc.) currently install the **Full** (`nexttrace`) version only.
 
 ### Feature Matrix
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,7 @@ Please note, there are exceptions to this synchronization. If a version of NTrac
       curl -fsSL -o /tmp/nexttrace-archive-keyring.gpg https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg
       sudo install -m 0644 /tmp/nexttrace-archive-keyring.gpg /etc/apt/keyrings/nexttrace.gpg
       rm -f /tmp/nexttrace-archive-keyring.gpg
-      sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null <<'EOF'
-Types: deb
-URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
-Suites: ./
-Signed-By: /etc/apt/keyrings/nexttrace.gpg
-EOF
+      printf '%s\n' 'Types: deb' 'URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/' 'Suites: ./' 'Signed-By: /etc/apt/keyrings/nexttrace.gpg' | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
       sudo apt update
       sudo apt install nexttrace
       ```

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -64,11 +64,16 @@ Document Language: [English](README.md) | 简体中文
     - 当前支持：`amd64`、`i386`、`arm64`、`armel`、`armhf`、`loong64`、`mipsel`、`mips64el`、`ppc64el`、`riscv64`、`s390x`
     - 添加源并安装：
       ```shell
-      curl -fsSL https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg | sudo tee /etc/apt/keyrings/nexttrace.gpg >/dev/null
-      echo "Types: deb
-      URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
-      Suites: ./
-      Signed-By: /etc/apt/keyrings/nexttrace.gpg" | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
+      sudo install -d -m 0755 /etc/apt/keyrings
+      curl -fsSL -o /tmp/nexttrace-archive-keyring.gpg https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg
+      sudo install -m 0644 /tmp/nexttrace-archive-keyring.gpg /etc/apt/keyrings/nexttrace.gpg
+      rm -f /tmp/nexttrace-archive-keyring.gpg
+      sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null <<'EOF'
+Types: deb
+URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
+Suites: ./
+Signed-By: /etc/apt/keyrings/nexttrace.gpg
+EOF
       sudo apt update
       sudo apt install nexttrace
       ```

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -59,6 +59,27 @@ Document Language: [English](README.md) | 简体中文
 
 ### Automated Install
 
+- Debian / Ubuntu
+  - 推荐：通过官方 `nexttrace-debs` APT 源安装
+    - 当前支持：`amd64`、`i386`、`arm64`、`armel`、`armhf`、`loong64`、`mipsel`、`mips64el`、`ppc64el`、`riscv64`、`s390x`
+    - 添加源并安装：
+      ```shell
+      curl -fsSL https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg | sudo tee /etc/apt/keyrings/nexttrace.gpg >/dev/null
+      echo "Types: deb
+      URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
+      Suites: ./
+      Signed-By: /etc/apt/keyrings/nexttrace.gpg" | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
+      sudo apt update
+      sudo apt install nexttrace
+      ```
+    - 安装指定 flavor：
+      ```shell
+      sudo apt install nexttrace
+      sudo apt install nexttrace-tiny
+      sudo apt install ntr
+      ```
+    - 三个包可以共存安装，对应命令分别是：`nexttrace`、`nexttrace-tiny`、`ntr`
+
 - Linux / macOS / BSD
   - 一键安装脚本（完整版，默认）
     ```shell
@@ -72,22 +93,7 @@ Document Language: [English](README.md) | 简体中文
     ```shell
     curl -sL https://nxtrace.org/nt | bash -s -- --flavor ntr
     ```
-  - 安装后的命令名：
-    - Full：`nexttrace`
-    - Tiny：`nexttrace-tiny`
-    - NTR：`ntr`
-  - 从 nxtrace的APT源安装
-    - 支持 AMD64/ARM64 架构
-      ```shell
-      curl -fsSL https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg | sudo tee /etc/apt/keyrings/nexttrace.gpg >/dev/null
-      echo "Types: deb
-      URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
-      Suites: ./
-      Signed-By: /etc/apt/keyrings/nexttrace.gpg" | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
-      sudo apt update
-      sudo apt install nexttrace
-      ```
-    - APT源由 wcbing, nxtrace 维护
+  - 安装后的命令名：Full `nexttrace`，Tiny `nexttrace-tiny`，NTR `ntr`
 
   - Arch Linux AUR 安装命令
     - 直接下载bin包(仅支持amd64)
@@ -154,7 +160,10 @@ Document Language: [English](README.md) | 简体中文
 
     - scoop-extra 由 soenggam 维护
 
-请注意，以上多种安装方式的仓库均由开源爱好者自行维护，不保证可用性和及时更新，如遇到问题请联系仓库维护者解决，或使用本项目官方编译提供的二进制包。
+请注意：
+
+- `nexttrace-debs` APT 源由 nxtrace 和 wcbing 维护。
+- 其它安装方式中的软件源大多由开源爱好者自行维护，不保证可用性和及时更新；如遇到问题请联系对应维护者，或使用本项目官方编译提供的二进制包。
 
 ### Manual Install
 
@@ -182,7 +191,7 @@ Document Language: [English](README.md) | 简体中文
 | 默认运行模式            |      traceroute       |    traceroute    |  MTR TUI   |
 | 二进制名                |      `nexttrace`      | `nexttrace-tiny` |   `ntr`    |
 
-> **注意：** 包管理器（Homebrew、AUR、Scoop 等）目前仅安装 **完整版**（`nexttrace`）。
+> **注意：** `APT (nexttrace-debs)` 目前提供 **Full**（`nexttrace`）、**Tiny**（`nexttrace-tiny`）和 **NTR**（`ntr`）三种包；其它包管理器（Homebrew、AUR、Scoop 等）目前仍仅提供 **完整版**（`nexttrace`）。
 
 ### 功能对比
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -68,12 +68,7 @@ Document Language: [English](README.md) | 简体中文
       curl -fsSL -o /tmp/nexttrace-archive-keyring.gpg https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg
       sudo install -m 0644 /tmp/nexttrace-archive-keyring.gpg /etc/apt/keyrings/nexttrace.gpg
       rm -f /tmp/nexttrace-archive-keyring.gpg
-      sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null <<'EOF'
-Types: deb
-URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/
-Suites: ./
-Signed-By: /etc/apt/keyrings/nexttrace.gpg
-EOF
+      printf '%s\n' 'Types: deb' 'URIs: https://github.com/nxtrace/nexttrace-debs/releases/latest/download/' 'Suites: ./' 'Signed-By: /etc/apt/keyrings/nexttrace.gpg' | sudo tee /etc/apt/sources.list.d/nexttrace.sources >/dev/null
       sudo apt update
       sudo apt install nexttrace
       ```

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -62,7 +62,7 @@ Document Language: [English](README.md) | 简体中文
 - Debian / Ubuntu
   - 推荐：通过官方 `nexttrace-debs` APT 源安装
     - 当前支持：`amd64`、`i386`、`arm64`、`armel`、`armhf`、`loong64`、`mipsel`、`mips64el`、`ppc64el`、`riscv64`、`s390x`
-    - 添加源并安装：
+    - 添加源并安装默认包：
       ```shell
       sudo install -d -m 0755 /etc/apt/keyrings
       curl -fsSL -o /tmp/nexttrace-archive-keyring.gpg https://github.com/nxtrace/nexttrace-debs/releases/latest/download/nexttrace-archive-keyring.gpg
@@ -72,9 +72,8 @@ Document Language: [English](README.md) | 简体中文
       sudo apt update
       sudo apt install nexttrace
       ```
-    - 安装指定 flavor：
+    - 可选：安装额外的 flavor：
       ```shell
-      sudo apt install nexttrace
       sudo apt install nexttrace-tiny
       sudo apt install ntr
       ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 新增 Debian / Ubuntu 专用 “Automated Install” 子节，推荐使用官方 nexttrace-debs APT 仓库，并列出支持架构与逐步安装命令。
  * 在通用 “Linux / macOS / BSD” 安装节中移除详细 APT 指引，保留已安装命令名称说明（nexttrace / nexttrace-tiny / ntr）。
  * 明确 nexttrace-debs 仓库维护者为 nxtrace 与 wcbing，其他来源为社区维护并可能滞后。
  * 说明 APT（nexttrace-debs）当前提供 Full/Tiny/NTR 三个变体，其他包管理器仍仅提供 Full 版本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->