### PR TITLE
[codex] Restore Windows --dev source selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,7 +290,8 @@
 - `--dev` 在 `cmd/cmd.go` 先解析网卡并推导 `srcAddr`（已处理非 `*net.IPNet` 地址类型，避免 panic）。
 - `trace.Config` 现在显式携带 `SourceDevice` / `DisableMPLS`，Darwin TCP/UDP 抓包与 MPLS 解析优先走会话级配置，不再依赖 Web 侧临时改写全局变量。
 - `trace.Config` 也显式携带 `Context`；`TracerouteWithContext(...)` 通过把上游 ctx 传入各 tracer 的 `signal.NotifyContext(...)` 基底，让 TCP/UDP fallback MTR 可以响应取消。
-- Windows TCP 目前仍无法把 `SourceDevice` 映射到 WinDivert 接口选择；当前策略是显式报错拒绝，而不是静默忽略该字段。
+- Windows 下 ICMP/TCP/UDP 的 `--dev` 都必须保持 v1.6.2 兼容行为：先解析指定网卡对应的 source IP，写入 `SrcAddr`，再清空 `SourceDevice`，让后续路径按 source address 继续运行；不要把 Windows `--dev` 改成拒绝执行或报错退出。
+- 这只是通过 source IP 影响 Windows 路由选择，不代表 WinDivert 或 socket 已支持真实按设备绑定；README 需要如实说明可能不准确。独立 `--mtu` 同样按 source-address 发送，但可额外保留 device 名用于本地 MTU 查询。
 - MTR 标题显示源信息来自：
   - `--source`（最高优先）
   - `--dev` 推导

--- a/README.md
+++ b/README.md
@@ -333,8 +333,7 @@ nexttrace --file /path/to/your/iplist.txt
 #### `NextTrace` already supports route tracing for specified Network Devices
 
 On macOS and Linux, `--dev` binds the requested source interface.
-On Windows, `--dev` only selects the source address and does not guarantee the actual egress interface.
-`TCP + --dev` remains explicitly unsupported on Windows and returns an error.
+On Windows, `--dev` resolves the source IP from the selected device and uses that source address for ICMP/TCP/UDP probes; it does not bind WinDivert or sockets to a real egress interface, so Windows routing may still choose a different path. The standalone `--mtu` mode follows the same source-address behavior and also uses the device name for local MTU lookup.
 
 ```bash
 # Use eth0 network interface
@@ -818,8 +817,9 @@ Arguments:
                                      packets
   -D  --dev                          Use the specified network device for
                                      explicit source selection. On Windows,
-                                     this only chooses the source address and
-                                     does not guarantee the egress interface
+                                     this selects the device source address;
+                                     routing may still choose the egress
+                                     interface
       --listen                       Set listen address for web console (e.g.
                                      127.0.0.1:30080)
       --deploy                       Start the Gin powered web console

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -331,8 +331,7 @@ nexttrace --file /path/to/your/iplist.txt
 #### `NextTrace` 已支持指定网卡进行路由跟踪
 
 在 macOS 和 Linux 上，`--dev` 会绑定到指定源网卡。
-在 Windows 上，`--dev` 只用于选择 source address，不保证真实出接口。
-`TCP + --dev` 在 Windows 上仍然是显式不支持的，会直接报错。
+在 Windows 上，`--dev` 会从指定网卡解析 source IP，并用该 source address 发起 ICMP/TCP/UDP 探测；它不会把 WinDivert 或 socket 绑定到真实出接口，实际出口仍可能由 Windows 路由表决定。独立 `--mtu` 模式也遵循相同的 source-address 语义，并额外使用网卡名查询本地 MTU。
 
 ```bash
 # 请注意 Lite 版本此参数不能和快速测试联用，如有需要请使用 enhanced 版本
@@ -794,8 +793,9 @@ Arguments:
                                      packets
   -D  --dev                          Use the specified network device for
                                      explicit source selection. On Windows,
-                                     this only chooses the source address and
-                                     does not guarantee the egress interface
+                                     this selects the device source address;
+                                     routing may still choose the egress
+                                     interface
       --listen                       Set listen address for web console (e.g.
                                      127.0.0.1:30080)
       --deploy                       Start the Gin powered web console

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1092,7 +1092,7 @@ func Execute() {
 	naliMode := registerNaliFlag(parser)
 	srcAddr := parser.String("s", "source", &argparse.Options{Help: "Use source address src_addr for outgoing packets"})
 	srcPort := parser.Int("", "source-port", &argparse.Options{Help: "Use source port src_port for outgoing packets"})
-	srcDev := parser.String("D", "dev", &argparse.Options{Help: "Use the specified network device for explicit source selection. On Windows, this only chooses the source address and does not guarantee the egress interface; TCP + --dev is not supported"})
+	srcDev := parser.String("D", "dev", &argparse.Options{Help: "Use the specified network device for explicit source selection. On Windows, this selects the device source address; routing may still choose the egress interface"})
 
 	webFlags := registerWebUIFlags(parser)
 	deployListen := webFlags.deployListen
@@ -1298,7 +1298,7 @@ func Execute() {
 			fmt.Println(srcResolveErr)
 			os.Exit(1)
 		}
-		// NormalizeExplicitSourceConfig enforces explicit --source/--dev rules and unsupported combinations.
+		// NormalizeExplicitSourceConfig applies explicit --source/--dev selection rules.
 		sourceCfg, srcResolveErr := trace.NormalizeExplicitSourceConfig(trace.UDPTrace, trace.Config{
 			OSType:       osType,
 			DstIP:        ip,
@@ -1436,7 +1436,7 @@ func Execute() {
 		fmt.Println(srcResolveErr)
 		os.Exit(1)
 	}
-	// NormalizeExplicitSourceConfig enforces explicit --source/--dev rules and unsupported combinations.
+	// NormalizeExplicitSourceConfig applies explicit --source/--dev selection rules.
 	sourceCfg, srcResolveErr := trace.NormalizeExplicitSourceConfig(method, trace.Config{
 		OSType:       osType,
 		DstIP:        ip,

--- a/trace/source_config.go
+++ b/trace/source_config.go
@@ -120,6 +120,8 @@ func ResolveConfiguredSrcAddr(dstIP net.IP, srcAddr, srcDev string) (resolved st
 }
 
 func NormalizeExplicitSourceConfig(method Method, config Config) (Config, error) {
+	_ = method
+
 	config.SrcAddr = strings.TrimSpace(config.SrcAddr)
 	config.SourceDevice = strings.TrimSpace(config.SourceDevice)
 	explicitSource := config.SrcAddr != ""
@@ -129,9 +131,6 @@ func NormalizeExplicitSourceConfig(method Method, config Config) (Config, error)
 	}
 	if config.SourceDevice == "" {
 		return config, nil
-	}
-	if config.OSType == osTypeWindows && method == TCPTrace {
-		return config, fmt.Errorf("source_device %q is not supported on Windows TCP traces", config.SourceDevice)
 	}
 	if config.OSType == osTypeWindows && explicitSource {
 		config.SourceDevice = ""

--- a/trace/source_config_test.go
+++ b/trace/source_config_test.go
@@ -300,12 +300,14 @@ func TestNormalizeExplicitSourceConfigWindowsIgnoresDeviceWhenSourceExplicitForI
 	}
 }
 
-func TestNormalizeExplicitSourceConfigWindowsRejectsTCPSourceDevice(t *testing.T) {
+func TestNormalizeExplicitSourceConfigWindowsTCPResolvesDeviceToSourceAddress(t *testing.T) {
 	restore := stubSourceDeviceResolver(t, func(device string) (*net.Interface, error) {
-		t.Fatalf("ResolveSourceDevice should not be called for unsupported Windows TCP source_device")
-		return nil, nil
+		if device != "Ethernet0" {
+			t.Fatalf("ResolveSourceDevice device = %q, want Ethernet0", device)
+		}
+		return &net.Interface{Name: device}, nil
 	}, func(_ *net.Interface) ([]net.Addr, error) {
-		return nil, nil
+		return []net.Addr{&net.IPNet{IP: net.ParseIP("192.0.2.44"), Mask: net.CIDRMask(24, 32)}}, nil
 	})
 	defer restore()
 
@@ -315,12 +317,15 @@ func TestNormalizeExplicitSourceConfigWindowsRejectsTCPSourceDevice(t *testing.T
 		SourceDevice: "Ethernet0",
 	}
 
-	_, err := NormalizeExplicitSourceConfig(TCPTrace, cfg)
-	if err == nil {
-		t.Fatal("NormalizeExplicitSourceConfig() error = nil, want unsupported Windows TCP source_device error")
+	got, err := NormalizeExplicitSourceConfig(TCPTrace, cfg)
+	if err != nil {
+		t.Fatalf("NormalizeExplicitSourceConfig() error = %v", err)
 	}
-	if err.Error() != `source_device "Ethernet0" is not supported on Windows TCP traces` {
-		t.Fatalf("err = %q, want unsupported Windows TCP source_device error", err.Error())
+	if got.SrcAddr != "192.0.2.44" {
+		t.Fatalf("SrcAddr = %q, want 192.0.2.44", got.SrcAddr)
+	}
+	if got.SourceDevice != "" {
+		t.Fatalf("SourceDevice = %q, want empty", got.SourceDevice)
 	}
 }
 


### PR DESCRIPTION
## Summary
- restore Windows `--dev` handling so ICMP/TCP/UDP resolve the selected device to a source IP instead of rejecting TCP
- document that Windows uses `--dev` as source-address selection, not real egress-interface binding
- preserve the `--mtu` note that the device name may still be used for local MTU lookup

## Why
A previous change made Windows `TCP + --dev` fail before reaching the tracer. That regressed the v1.6.2-compatible behavior where Windows derives a source IP from the selected device and lets Windows routing choose the actual egress path.

## Validation
- `go test ./trace ./cmd`
- `go test ./...`
