### PR TITLE
[codex] fast-trace 复用 v4 token runtime 初始化

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -53,6 +53,7 @@ var (
 	prepareNextTraceAPIV4FastIPFn = ipgeo.PrepareNextTraceAPIV4FastIP
 	newLeoWebsocketFn             = wshandle.NewWithContext
 	newLeoWebsocketAsyncFn        = wshandle.NewWithContextAsync
+	runFastTraceFn                = fastTrace.FastTest
 )
 
 func normalizeListenAddr(addr string) string {
@@ -801,12 +802,21 @@ func maybeRunFastTraceMode(from string, fastTraceFlag bool, file string, params 
 	if from != "" || (!fastTraceFlag && file == "") {
 		return false
 	}
-	fastTrace.FastTest(method, params)
+	runFastTraceFn(method, params)
 	if params.OutputPath != "" {
 		fmt.Printf("您的追踪日志已经存放在 %s 中\n", params.OutputPath)
 	}
-	os.Exit(0)
 	return true
+}
+
+func runFastTraceModeWithRuntime(ctx context.Context, dn42 bool, dataOrigin *string, disableMaptrace *bool, powProvider *string, from string, fastTraceFlag bool, file string, params fastTrace.ParamsFastTrace, method trace.Method) bool {
+	if from != "" || (!fastTraceFlag && file == "") {
+		return false
+	}
+	leoWs := prepareRuntimeEnvironment(ctx, dn42, dataOrigin, disableMaptrace, powProvider, false)
+	defer closeLeoWebsocket(leoWs)
+	params.RuntimePrepared = true
+	return maybeRunFastTraceMode(from, fastTraceFlag, file, params, method)
 }
 
 func configureGeoDNS(dot string) {
@@ -1515,7 +1525,7 @@ func Execute() {
 		Dot:            *dot,
 		OutputPath:     resolvedOutputPath,
 	}
-	if maybeRunFastTraceMode(*from, *fastTraceFlag, *file, paramsFastTrace, method) {
+	if runFastTraceModeWithRuntime(rootCtx, *dn42, dataOrigin, disableMaptrace, powProvider, *from, *fastTraceFlag, *file, paramsFastTrace, method) {
 		return
 	}
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/akamensky/argparse"
+	fastTrace "github.com/nxtrace/NTrace-core/fast_trace"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/tracelog"
 	"github.com/nxtrace/NTrace-core/util"
@@ -106,6 +109,70 @@ func TestInitLeoWebsocketSkipsV3WhenNextTraceAPIV4TokenConfigured(t *testing.T) 
 	}
 }
 
+func TestInitLeoWebsocketSkipsV3WhenNextTraceAPIV4TokenFileConfigured(t *testing.T) {
+	tests := []struct {
+		name      string
+		writePath func(paths nextTraceAPIV4TokenPaths) string
+	}{
+		{
+			name: "session",
+			writePath: func(paths nextTraceAPIV4TokenPaths) string {
+				return paths.session
+			},
+		},
+		{
+			name: "latest",
+			writePath: func(paths nextTraceAPIV4TokenPaths) string {
+				return paths.latest
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := isolateCmdNextTraceAPIV4TokenFiles(t)
+			writeNextTraceAPIV4TokenFileForTest(t, tt.writePath(paths), "file-token\n")
+			oldPrepare := prepareNextTraceAPIV4FastIPFn
+			oldNewLeo := newLeoWebsocketFn
+			var prepareCalls int
+			var wsCalls int
+			prepareNextTraceAPIV4FastIPFn = func(ctx context.Context, enableOutput bool) error {
+				prepareCalls++
+				if ctx == nil {
+					t.Fatal("PrepareNextTraceAPIV4FastIP context = nil")
+				}
+				if !enableOutput {
+					t.Fatal("PrepareNextTraceAPIV4FastIP enableOutput = false, want true")
+				}
+				return nil
+			}
+			newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+				wsCalls++
+				return nil
+			}
+			t.Cleanup(func() {
+				prepareNextTraceAPIV4FastIPFn = oldPrepare
+				newLeoWebsocketFn = oldNewLeo
+			})
+			dataProvider := "LeoMoeAPI"
+			powProvider := "api.nxtrace.org"
+
+			if got := initLeoWebsocket(context.Background(), &dataProvider, &powProvider, false); got != nil {
+				t.Fatalf("initLeoWebsocket() = %+v, want nil when NextTrace API v4 token file is configured", got)
+			}
+			if prepareCalls != 1 {
+				t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
+			}
+			if wsCalls != 0 {
+				t.Fatalf("Leo WS calls = %d, want 0 when API v4 preheat succeeds", wsCalls)
+			}
+			if got := os.Getenv(util.EnvNextTraceAPIV4TokenKey); got != "file-token" {
+				t.Fatalf("%s = %q, want token loaded from file", util.EnvNextTraceAPIV4TokenKey, got)
+			}
+		})
+	}
+}
+
 func TestInitLeoWebsocketFallsBackToV3WhenAPIV4FastIPFails(t *testing.T) {
 	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
 	oldPrepare := prepareNextTraceAPIV4FastIPFn
@@ -133,6 +200,152 @@ func TestInitLeoWebsocketFallsBackToV3WhenAPIV4FastIPFails(t *testing.T) {
 	}
 	if wsCalls != 1 {
 		t.Fatalf("Leo WS calls = %d, want 1 after API v4 preheat failure", wsCalls)
+	}
+}
+
+func TestInitLeoWebsocketFallsBackToV3WhenAPIV4TokenMissing(t *testing.T) {
+	isolateCmdNextTraceAPIV4TokenFiles(t)
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	oldNewLeo := newLeoWebsocketFn
+	var prepareCalls int
+	var wsCalls int
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+		prepareCalls++
+		return nil
+	}
+	newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+		wsCalls++
+		return nil
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+		newLeoWebsocketFn = oldNewLeo
+	})
+	dataProvider := "LeoMoeAPI"
+	powProvider := "api.nxtrace.org"
+
+	_ = initLeoWebsocket(context.Background(), &dataProvider, &powProvider, false)
+	if prepareCalls != 0 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 0 without API v4 token", prepareCalls)
+	}
+	if wsCalls != 1 {
+		t.Fatalf("Leo WS calls = %d, want 1 without API v4 token", wsCalls)
+	}
+}
+
+func TestRunFastTraceModePreparesRuntimeAndMarksParams(t *testing.T) {
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "v4-token")
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	oldNewLeo := newLeoWebsocketFn
+	oldRunFastTrace := runFastTraceFn
+	var prepareCalls int
+	var wsCalls int
+	var runCalls int
+	var gotRuntimePrepared bool
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+		prepareCalls++
+		return nil
+	}
+	newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+		wsCalls++
+		return nil
+	}
+	runFastTraceFn = func(_ trace.Method, params fastTrace.ParamsFastTrace) {
+		runCalls++
+		gotRuntimePrepared = params.RuntimePrepared
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+		newLeoWebsocketFn = oldNewLeo
+		runFastTraceFn = oldRunFastTrace
+	})
+	dataProvider := "LeoMoeAPI"
+	disableMaptrace := false
+	powProvider := "api.nxtrace.org"
+
+	if !runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+		t.Fatal("runFastTraceModeWithRuntime returned false, want true")
+	}
+	if prepareCalls != 1 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 1", prepareCalls)
+	}
+	if wsCalls != 0 {
+		t.Fatalf("Leo WS calls = %d, want 0 when API v4 preheat succeeds", wsCalls)
+	}
+	if runCalls != 1 {
+		t.Fatalf("FastTest calls = %d, want 1", runCalls)
+	}
+	if !gotRuntimePrepared {
+		t.Fatal("FastTest RuntimePrepared = false, want true")
+	}
+}
+
+func TestRunFastTraceModeSkipsRuntimeForGlobalpingFrom(t *testing.T) {
+	oldPrepare := prepareNextTraceAPIV4FastIPFn
+	oldNewLeo := newLeoWebsocketFn
+	oldRunFastTrace := runFastTraceFn
+	var prepareCalls int
+	var wsCalls int
+	var runCalls int
+	prepareNextTraceAPIV4FastIPFn = func(context.Context, bool) error {
+		prepareCalls++
+		return nil
+	}
+	newLeoWebsocketFn = func(context.Context) *wshandle.WsConn {
+		wsCalls++
+		return nil
+	}
+	runFastTraceFn = func(trace.Method, fastTrace.ParamsFastTrace) {
+		runCalls++
+	}
+	t.Cleanup(func() {
+		prepareNextTraceAPIV4FastIPFn = oldPrepare
+		newLeoWebsocketFn = oldNewLeo
+		runFastTraceFn = oldRunFastTrace
+	})
+	dataProvider := "LeoMoeAPI"
+	disableMaptrace := false
+	powProvider := "api.nxtrace.org"
+
+	if runFastTraceModeWithRuntime(context.Background(), false, &dataProvider, &disableMaptrace, &powProvider, "tokyo", true, "", fastTrace.ParamsFastTrace{}, trace.ICMPTrace) {
+		t.Fatal("runFastTraceModeWithRuntime returned true for --from, want false")
+	}
+	if prepareCalls != 0 {
+		t.Fatalf("PrepareNextTraceAPIV4FastIP calls = %d, want 0 for --from", prepareCalls)
+	}
+	if wsCalls != 0 {
+		t.Fatalf("Leo WS calls = %d, want 0 for --from", wsCalls)
+	}
+	if runCalls != 0 {
+		t.Fatalf("FastTest calls = %d, want 0 for --from", runCalls)
+	}
+}
+
+type nextTraceAPIV4TokenPaths struct {
+	session string
+	latest  string
+}
+
+func isolateCmdNextTraceAPIV4TokenFiles(t *testing.T) nextTraceAPIV4TokenPaths {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TMP", dir)
+	t.Setenv("TEMP", dir)
+	t.Setenv(util.EnvNextTraceAPIV4TokenKey, "")
+	return nextTraceAPIV4TokenPaths{
+		session: util.NextTraceAPIV4SessionTokenPath(),
+		latest:  util.NextTraceAPIV4LatestTokenPath(),
+	}
+}
+
+func writeNextTraceAPIV4TokenFileForTest(t *testing.T, path, token string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("MkdirAll token dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		t.Fatalf("WriteFile token: %v", err)
 	}
 }
 

--- a/fast_trace/fast_trace ipv6.go
+++ b/fast_trace/fast_trace ipv6.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
-	"os/signal"
 	"strings"
 
 	"github.com/fatih/color"
@@ -14,7 +12,6 @@ import (
 	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/trace"
 	"github.com/nxtrace/NTrace-core/util"
-	"github.com/nxtrace/NTrace-core/wshandle"
 )
 
 //var pFastTracer ParamsFastTrace
@@ -163,13 +160,8 @@ func FastTestv6(traceMode trace.Method, paramsFastTrace ParamsFastTrace) {
 		TracerouteMethod: fastTestMethod(traceMode),
 	}
 
-	// 建立 WebSocket 连接
-	w := wshandle.NewWithContext(paramsFastTrace.Context)
-	w.Interrupt = make(chan os.Signal, 1)
-	signal.Notify(w.Interrupt, os.Interrupt)
-	defer func() {
-		w.Close()
-	}()
+	cleanupWS := openFastTraceWSIfNeeded(paramsFastTrace)
+	defer cleanupWS()
 
 	runFastTestv6Selection(&ft, choice)
 }

--- a/fast_trace/fast_trace.go
+++ b/fast_trace/fast_trace.go
@@ -29,25 +29,26 @@ type FastTracer struct {
 }
 
 type ParamsFastTrace struct {
-	Context        context.Context
-	OSType         int
-	ICMPMode       int
-	SrcDev         string
-	SrcAddr        string
-	DstPort        int
-	BeginHop       int
-	MaxHops        int
-	MaxAttempts    int
-	RDNS           bool
-	AlwaysWaitRDNS bool
-	Lang           string
-	PktSize        int
-	PacketSizeSet  bool
-	TOS            int
-	Timeout        time.Duration
-	File           string
-	Dot            string
-	OutputPath     string
+	Context         context.Context
+	OSType          int
+	ICMPMode        int
+	SrcDev          string
+	SrcAddr         string
+	DstPort         int
+	BeginHop        int
+	MaxHops         int
+	MaxAttempts     int
+	RDNS            bool
+	AlwaysWaitRDNS  bool
+	Lang            string
+	PktSize         int
+	PacketSizeSet   bool
+	TOS             int
+	Timeout         time.Duration
+	File            string
+	Dot             string
+	OutputPath      string
+	RuntimePrepared bool
 }
 
 type IpListElement struct {
@@ -118,6 +119,21 @@ func initFastTraceWS(ctx context.Context) *wshandle.WsConn {
 func closeFastTraceWS(w *wshandle.WsConn) {
 	if w != nil {
 		w.Close()
+	}
+}
+
+var (
+	initFastTraceWSFn  = initFastTraceWS
+	closeFastTraceWSFn = closeFastTraceWS
+)
+
+func openFastTraceWSIfNeeded(params ParamsFastTrace) func() {
+	if params.RuntimePrepared {
+		return func() {}
+	}
+	w := initFastTraceWSFn(params.Context)
+	return func() {
+		closeFastTraceWSFn(w)
 	}
 }
 
@@ -413,15 +429,15 @@ func FastTest(traceMode trace.Method, paramsFastTrace ParamsFastTrace) {
 		return
 	}
 
-	w := initFastTraceWS(paramsFastTrace.Context)
-	defer closeFastTraceWS(w)
+	cleanupWS := openFastTraceWSIfNeeded(paramsFastTrace)
+	defer cleanupWS()
 
 	runFastTraceByChoice(newFastTracer(traceMode, paramsFastTrace), choice)
 }
 
 func testFile(paramsFastTrace ParamsFastTrace, traceMode trace.Method) {
-	w := initFastTraceWS(paramsFastTrace.Context)
-	defer closeFastTraceWS(w)
+	cleanupWS := openFastTraceWSIfNeeded(paramsFastTrace)
+	defer cleanupWS()
 
 	tracerouteMethod := resolveTraceMethod(traceMode)
 	for _, ip := range loadIPList(paramsFastTrace.Context, paramsFastTrace.File) {

--- a/fast_trace/fast_trace_test.go
+++ b/fast_trace/fast_trace_test.go
@@ -2,8 +2,12 @@ package fastTrace
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/nxtrace/NTrace-core/trace"
+	"github.com/nxtrace/NTrace-core/wshandle"
 )
 
 func TestTrace(t *testing.T) {
@@ -74,4 +78,76 @@ func TestReadFastTestv6ChoiceCanceledContext(t *testing.T) {
 	if choice != "" {
 		t.Fatalf("readFastTestv6Choice choice = %q, want empty", choice)
 	}
+}
+
+func TestTestFileSkipsFastTraceWSWhenRuntimePrepared(t *testing.T) {
+	file := emptyFastTraceFile(t)
+	oldInit := initFastTraceWSFn
+	oldClose := closeFastTraceWSFn
+	var initCalls int
+	var closeCalls int
+	initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
+		initCalls++
+		return nil
+	}
+	closeFastTraceWSFn = func(*wshandle.WsConn) {
+		closeCalls++
+	}
+	t.Cleanup(func() {
+		initFastTraceWSFn = oldInit
+		closeFastTraceWSFn = oldClose
+	})
+
+	testFile(ParamsFastTrace{
+		Context:         context.Background(),
+		File:            file,
+		RuntimePrepared: true,
+	}, trace.ICMPTrace)
+
+	if initCalls != 0 {
+		t.Fatalf("initFastTraceWS calls = %d, want 0 when runtime is prepared", initCalls)
+	}
+	if closeCalls != 0 {
+		t.Fatalf("closeFastTraceWS calls = %d, want 0 when runtime is prepared", closeCalls)
+	}
+}
+
+func TestTestFileInitializesFastTraceWSByDefault(t *testing.T) {
+	file := emptyFastTraceFile(t)
+	oldInit := initFastTraceWSFn
+	oldClose := closeFastTraceWSFn
+	var initCalls int
+	var closeCalls int
+	initFastTraceWSFn = func(context.Context) *wshandle.WsConn {
+		initCalls++
+		return nil
+	}
+	closeFastTraceWSFn = func(*wshandle.WsConn) {
+		closeCalls++
+	}
+	t.Cleanup(func() {
+		initFastTraceWSFn = oldInit
+		closeFastTraceWSFn = oldClose
+	})
+
+	testFile(ParamsFastTrace{
+		Context: context.Background(),
+		File:    file,
+	}, trace.ICMPTrace)
+
+	if initCalls != 1 {
+		t.Fatalf("initFastTraceWS calls = %d, want 1 by default", initCalls)
+	}
+	if closeCalls != 1 {
+		t.Fatalf("closeFastTraceWS calls = %d, want 1 by default", closeCalls)
+	}
+}
+
+func emptyFastTraceFile(t *testing.T) string {
+	t.Helper()
+	path := t.TempDir() + "/targets.txt"
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile targets: %v", err)
+	}
+	return path
 }


### PR DESCRIPTION
### Summary

- 统一 fast-trace (`-F` / `--file`) 进入前的 LeoMoeAPI runtime 初始化路径。
- 为 `fast_trace.ParamsFastTrace` 增加 `RuntimePrepared`，避免已预热 runtime 后重复初始化 v3 WS。
- 补充 env token、session/latest token 文件、fallback 和 `--from` 路径测试。

### Motivation

fast-trace 之前绕过普通单目标路径的 runtime 初始化，导致 v4 token 已通过环境变量或 `nexttrace -x` session/latest token 文件配置时，不能先完成 v4 FastIP prewarm 再决定是否跳过 v3 WebSocket 初始化。

### Changes

- `cmd` 在 fast-trace 前复用 `prepareRuntimeEnvironment(..., asyncLeo=false)`，并通过正常 return 结束流程。
- `maybeRunFastTraceMode` 不再调用 `os.Exit(0)`，使 fast-trace runtime 的 defer 清理可以执行。
- `FastTest`、`testFile`、`FastTestv6` 在 `RuntimePrepared=true` 时跳过内部 v3 WS 初始化；默认 false 保持直接调用旧行为。
- 新增单元测试覆盖 v4 token 来源、prewarm 失败 fallback、无 token fallback、`--from` 不进入 fast-trace runtime。

### Testing

- `go test ./cmd ./fast_trace ./util ./ipgeo`
- `go test ./...`
- `go build ./...`
- `git diff --check`

### Notes for Reviewers

- 未修改 `ipgeo/`、`wshandle/`、README、`go.mod`、`go.sum`。
- 本地分支名使用 `codex-fast-trace-v4-runtime`，因为当前 checkout 的 packed refs 阻止创建新的 `codex/...` 层级 ref。