### PR TITLE
docs(readme): 切换 lint 状态徽标到 GitHub Actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,49 @@
+name: golangci-lint
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".golangci.yml"
+      - ".github/workflows/golangci-lint.yml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".golangci.yml"
+      - ".github/workflows/golangci-lint.yml"
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v7
+
+      - name: Set up Go (built-in cache)
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.4"
+          check-latest: true
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12
+          only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go (built-in cache)
         uses: actions/setup-go@v6

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
   <a href="https://github.com/nxtrace/NTrace-dev/actions">
     <img src="https://img.shields.io/github/actions/workflow/status/nxtrace/NTrace-dev/build.yml?branch=main&style=flat-square" alt="Github Actions">
   </a>
-  <a href="https://goreportcard.com/report/github.com/nxtrace/NTrace-dev">
-    <img src="https://goreportcard.com/badge/github.com/nxtrace/NTrace-dev?style=flat-square">
+  <a href="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml">
+    <img src="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml/badge.svg?branch=main" alt="golangci-lint">
   </a>
   <a href="https://github.com/nxtrace/NTrace-dev/releases">
     <img src="https://img.shields.io/github/release/nxtrace/NTrace-dev/all.svg?style=flat-square">

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/nxtrace/NTrace-dev/build.yml?branch=main&style=flat-square" alt="Github Actions">
   </a>
   <a href="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml">
-    <img src="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml/badge.svg?branch=main" alt="golangci-lint">
+    <img src="https://img.shields.io/github/actions/workflow/status/nxtrace/NTrace-dev/golangci-lint.yml?branch=main&style=flat-square&label=golangci-lint" alt="golangci-lint">
   </a>
   <a href="https://github.com/nxtrace/NTrace-dev/releases">
     <img src="https://img.shields.io/github/release/nxtrace/NTrace-dev/all.svg?style=flat-square">

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -18,8 +18,8 @@
   <a href="https://github.com/nxtrace/NTrace-dev/actions">
     <img src="https://img.shields.io/github/actions/workflow/status/nxtrace/NTrace-dev/build.yml?branch=main&style=flat-square" alt="Github Actions">
   </a>
-  <a href="https://goreportcard.com/report/github.com/nxtrace/NTrace-dev">
-    <img src="https://goreportcard.com/badge/github.com/nxtrace/NTrace-dev?style=flat-square">
+  <a href="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml">
+    <img src="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml/badge.svg?branch=main" alt="golangci-lint">
   </a>
   <a href="https://github.com/nxtrace/NTrace-dev/releases">
     <img src="https://img.shields.io/github/release/nxtrace/NTrace-dev/all.svg?style=flat-square">

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -19,7 +19,7 @@
     <img src="https://img.shields.io/github/actions/workflow/status/nxtrace/NTrace-dev/build.yml?branch=main&style=flat-square" alt="Github Actions">
   </a>
   <a href="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml">
-    <img src="https://github.com/nxtrace/NTrace-dev/actions/workflows/golangci-lint.yml/badge.svg?branch=main" alt="golangci-lint">
+    <img src="https://img.shields.io/github/actions/workflow/status/nxtrace/NTrace-dev/golangci-lint.yml?branch=main&style=flat-square&label=golangci-lint" alt="golangci-lint">
   </a>
   <a href="https://github.com/nxtrace/NTrace-dev/releases">
     <img src="https://img.shields.io/github/release/nxtrace/NTrace-dev/all.svg?style=flat-square">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **持续集成**
  * 新增 Go 代码质量检查工作流：在向主分支推送以及拉取请求创建、更新或重新打开时自动运行。
  * 基于变更范围触发：仅当涉及 Go 相关文件或相关配置/工作流文件时才执行，并且只反馈新增问题。
  * 启用并发分组与自动取消，减少重复运行并加快结果更新。
* **文档**
  * 更新中英文 README 的 GitHub Actions 状态徽章，展示代码质量检查状态（替换原 goreportcard 徽章）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->