### PR TITLE
docs(readme): 修复失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,4 +1132,4 @@ This Project uses [JetBrain Open-Source Project License](https://jb.gg/OpenSourc
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nxtrace/NTrace-core&type=Date)](https://star-history.com/#nxtrace/NTrace-core&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nxtrace/NTrace-core&type=Date)](https://star-history.dera.page/#nxtrace/NTrace-core&Date)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -1178,4 +1178,4 @@ LAX,US,California,Los Anegles
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nxtrace/NTrace-core&type=Date)](https://star-history.com/#nxtrace/NTrace-core&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nxtrace/NTrace-core&type=Date)](https://star-history.dera.page/#nxtrace/NTrace-core&Date)


### PR DESCRIPTION
当前 README 中的 Star History 图表已损坏，因为 GitHub 对 stargazer API 施加了限制。此改动切换到使用替代数据源、无需任何 API token 的同一域名托管服务，使图表恢复正常渲染。README 的中英文版本均已同步更新。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新英文和简体中文 README 中的 Star History 图表地址与链接。
  * 图表现已使用新的服务地址加载。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->