### PR TITLE
Add snapshot saving, exit summary, and help shortcuts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ on:
       - ".cross_compile.sh"
       - "scripts/test_nt_install.sh"
       - "scripts/test_mtr_session_pty.py"
+      - "scripts/test_mtr_snapshot_pty.py"
       - "scripts/perf/**"
       - ".github/workflows/*.yml"
   pull_request:
@@ -35,6 +36,7 @@ on:
       - ".cross_compile.sh"
       - "scripts/test_nt_install.sh"
       - "scripts/test_mtr_session_pty.py"
+      - "scripts/test_mtr_snapshot_pty.py"
       - "scripts/perf/**"
       - ".github/workflows/*.yml"
   workflow_dispatch:
@@ -164,6 +166,7 @@ jobs:
             fi
             go build -buildvcs=false "${tags[@]}" -o "${binary}" .
             sudo python3 scripts/test_mtr_session_pty.py "${binary}"
+            sudo python3 scripts/test_mtr_snapshot_pty.py "${binary}"
           done
 
       - name: MTR session recording and replay ConPTY smoke
@@ -179,6 +182,8 @@ jobs:
             go @buildArgs .
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             python scripts/test_mtr_session_pty.py $binary
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            python scripts/test_mtr_snapshot_pty.py $binary
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 

--- a/README.md
+++ b/README.md
@@ -726,9 +726,13 @@ The `Fields:` page lists every code on a separate line. See [MTR column metrics]
 
 While editing, other shortcuts are inactive and Ctrl-C still exits. Editing does not pause probes, reset counters or change the paused state. Applying a selection from history view returns to the statistics table; cancellation preserves the view. History columns stay fixed. Changes last only for this session; editing and resizing work while paused.
 
+Live and replay TUI sessions can save the current cumulative statistics as `txt`, `json`, or a standalone `html` report with `s`. In the save dialog, Tab switches fields, Left/Right or Space changes the format, Enter saves, and Esc cancels. Saving never overwrites a file and does not pause or reset probing. Reports contain the current statistics and display settings; use `--mtr-record` for probe history and offline replay. See [MTR snapshot reports](docs/mtr-snapshot.md) for the JSON contract.
+
+After restoring the terminal, live and replay TUI sessions print a plain-text summary by default. Use `--no-mtr-summary` to suppress it. This flag does not enable MTR or change traditional traceroute and other MTR output formats. Standalone modes retain their own accepted options. Press `?` for complete help; Up/Down scroll, `?` or Esc closes help, and `q` or Ctrl-C exits.
+
 When running in a terminal (TTY), MTR mode uses an **interactive full-screen TUI**:
 
-- **`q` / `Q`** — quit (restores terminal, no output left behind)
+- **`q` / `Q`** — quit and restore the terminal
 - **`p`** — pause probing
 - **`SPACE`** — resume probing
 - **`r`** — reset statistics (counters are cleared, display mode is preserved)
@@ -738,6 +742,8 @@ When running in a terminal (TTY), MTR mode uses an **interactive full-screen TUI
   - with `--show-ips`: PTR (IP) ↔ IP only
 - **`e`** — toggle MPLS label display on/off
 - **`o` / `O`** — edit statistic columns
+- **`s` / `S`** — save the current report
+- **`?`** — open complete help
 - **`d` / `D`** — toggle the optional history display; the default TUI remains the classic metric table
 - **`g` / `G`** — in history display only, cycle History chart mode: heatmap → bars → sparkline
 - The TUI header displays **source → destination**, with `--source`/`--dev` information when specified.
@@ -969,7 +975,7 @@ usage: nexttrace [-h|--help] [-4|--ipv4] [-6|--ipv6] [-T|--tcp] [-U|--udp]
                  <integer>] [--timeout <integer>] [--psize <integer>] [-Q|--tos
                  <integer>] [--dot-server
                  (dnssb|aliyun|dnspod|google|cloudflare)] [-g|--language
-                 (en|cn)] [-C|--no-color] [--from "<value>"] [-t|--mtr]
+                 (en|cn)] [-C|--no-color] [--from "<value>"] [-t|--mtr] [--no-mtr-summary]
                  [-r|--report] [-w|--wide] [--show-ips] [--mtr-columns <string>] [-y|--ipinfo <integer>]
                  [--mtr-record "<value>"] [--file "<value>"] [TARGET "<value>"]
 
@@ -1103,6 +1109,8 @@ Arguments:
                                      cities, ASNs, ISPs, or cloud regions.
   -t  --mtr                          Enable MTR (My Traceroute) continuous
                                      probing mode
+      --no-mtr-summary               Suppress the summary printed after leaving
+                                     the MTR TUI
   -r  --report                       MTR report mode (non-interactive, implies
                                      --mtr); can trigger MTR without --mtr
   -w  --wide                         MTR wide report mode (implies --mtr

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -717,9 +717,13 @@ ntr --mtr-columns received 1.1.1.1
 
 编辑期间其他快捷键不生效，Ctrl-C 仍退出；探测、计数及暂停状态保持不变。从历史视图应用列后返回统计表，取消则保留历史视图。历史图表的固定列不变，列选择仅在当前会话有效；暂停期间仍可编辑和调整窗口大小。
 
+实时与回放 TUI 均可按 `s` 将当前累计统计保存为 `txt`、`json` 或独立 `html` 报告。保存窗口中，Tab 切换字段，左右方向键或空格切换格式，Enter 保存，Esc 取消。保存不覆盖已有文件，不暂停或重置探测。报告包含当前统计及显示设置；完整探测历史与离线回放使用 `--mtr-record`。JSON 契约见 [MTR 快照报告](docs/mtr-snapshot.md)。
+
+实时与回放 TUI 恢复终端后，默认输出纯文本摘要。`--no-mtr-summary` 关闭该摘要，不自动开启 MTR，不改变传统 traceroute 及其他 MTR 输出格式；独立模式仍遵守各自的参数规则。按 `?` 查看完整帮助；上下方向键滚动，`?` 或 Esc 关闭帮助，`q` 或 Ctrl-C 退出。
+
 在终端（TTY）中运行时，MTR 模式使用**交互式全屏 TUI**：
 
-- **`q` / `Q`** — 退出（恢复终端，不留下输出）
+- **`q` / `Q`** — 退出并恢复终端
 - **`p`** — 暂停探测
 - **空格** — 恢复探测
 - **`r`** — 重置统计（计数器清零，显示模式保持不变）
@@ -729,6 +733,8 @@ ntr --mtr-columns received 1.1.1.1
   - 启用 `--show-ips`：PTR (IP) ↔ 仅 IP
 - **`e`** — 切换 MPLS 标签显示开/关
 - **`o` / `O`** — 编辑统计列
+- **`s` / `S`** — 保存当前报告
+- **`?`** — 查看完整帮助
 - **`d` / `D`** — 切换可选历史显示；默认 TUI 仍是经典指标表
 - **`g` / `G`** — 仅在历史显示中循环切换 History 图表：heatmap → bars → sparkline
 - TUI 标题栏显示**源 → 目标**路由信息，指定 `--source`/`--dev` 时会展示对应信息。
@@ -944,7 +950,7 @@ usage: nexttrace [-h|--help] [-4|--ipv4] [-6|--ipv6] [-T|--tcp] [-U|--udp]
                  <integer>] [--timeout <integer>] [--psize <integer>] [-Q|--tos
                  <integer>] [--dot-server
                  (dnssb|aliyun|dnspod|google|cloudflare)] [-g|--language
-                 (en|cn)] [-C|--no-color] [--from "<value>"] [-t|--mtr]
+                 (en|cn)] [-C|--no-color] [--from "<value>"] [-t|--mtr] [--no-mtr-summary]
                  [-r|--report] [-w|--wide] [--show-ips] [--mtr-columns <string>] [-y|--ipinfo <integer>]
                  [--mtr-record "<value>"] [--file "<value>"] [TARGET "<value>"]
 
@@ -1078,6 +1084,8 @@ Arguments:
                                      cities, ASNs, ISPs, or cloud regions.
   -t  --mtr                          Enable MTR (My Traceroute) continuous
                                      probing mode
+      --no-mtr-summary               Suppress the summary printed after leaving
+                                     the MTR TUI
   -r  --report                       MTR report mode (non-interactive, implies
                                      --mtr); can trigger MTR without --mtr
   -w  --wide                         MTR wide report mode (implies --mtr

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -353,6 +353,7 @@ type deployRunOptions struct {
 
 type mtrCLIFlags struct {
 	columns    *string
+	noSummary  *bool
 	mtrMode    *bool
 	reportMode *bool
 	wideMode   *bool
@@ -571,6 +572,7 @@ func registerMTRFlags(parser *argparse.Parser) mtrCLIFlags {
 		}
 		return mtrCLIFlags{
 			mtrMode:    mtrMode,
+			noSummary:  parser.Flag("", "no-mtr-summary", &argparse.Options{Help: "Suppress the summary printed after leaving the MTR TUI"}),
 			columns:    parser.String("", "mtr-columns", &argparse.Options{Help: "MTR text columns in order: loss, snt, received, last, avg, best, wrst, stdev, dropped, gmean, jitter, javg, jmax, jint, space (does not enable MTR)"}),
 			reportMode: parser.Flag("r", "report", &argparse.Options{Help: "MTR report mode (non-interactive, implies --mtr); can trigger MTR without --mtr"}),
 			wideMode:   parser.Flag("w", "wide", &argparse.Options{Help: "MTR wide report mode (implies --mtr --report); alone equals --mtr --report --wide"}),
@@ -580,6 +582,7 @@ func registerMTRFlags(parser *argparse.Parser) mtrCLIFlags {
 	}
 	return mtrCLIFlags{
 		mtrMode:    ptrBool(false),
+		noSummary:  ptrBool(false),
 		columns:    new(string),
 		reportMode: ptrBool(false),
 		wideMode:   ptrBool(false),
@@ -1122,6 +1125,7 @@ func maybeRunMTRMode(
 	dataOrigin string,
 	showIPs bool,
 	ipInfoMode int,
+	presentation mtrTUIOptions,
 	columns ...printer.MTRColumn,
 ) bool {
 	if !modes.mtr {
@@ -1146,7 +1150,7 @@ func maybeRunMTRMode(
 			fmt.Fprintf(os.Stderr, "--ipinfo/-y 必须在 0-4 范围内，当前值: %d\n", ipInfoMode)
 			os.Exit(1)
 		}
-		err = runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode, nil, columns...)
+		err = runMTRTUI(method, conf, mtrHopIntervalMs, mtrMaxPerHop, domain, dataOrigin, showIPs, ipInfoMode, nil, presentation, columns...)
 	}
 	// Mode-local defers restore the terminal and close listeners before exit.
 	exitOnTraceRunError(err)
@@ -1606,6 +1610,7 @@ func Execute() {
 		count, interval := deriveMTRProbeParams(mtrModes.report, queriesSet, *numMeasurements, intervalSet, *ttlInterval)
 		opts := mtrJSONOptions{
 			Target: *str, Method: resolveTraceMethod(*tcp, *udp), Report: mtrModes.report,
+			NoSummary:     *mtrFlags.noSummary,
 			RecordPath:    *mtrRecord,
 			RecordDisplay: mtrRecordingDisplay{hostMode: *ipInfoMode, showIPs: *showIPs, wide: mtrModes.wide, columns: *mtrFlags.columns},
 			MaxPerHop:     count, HopIntervalMs: interval, PacketSize: *packetSize, PacketSizeExplicit: packetSet,
@@ -1987,7 +1992,8 @@ func Execute() {
 	conf.FWMark, conf.FWMarkSet = mark, fwmarkSet
 	conf.SrcPort = sourceCfg.SrcPort
 
-	if maybeRunMTRMode(mtrModes, method, conf, queriesExplicit, *numMeasurements, ttlTimeExplicit, *ttlInterval, domain, *dataOrigin, *showIPs, *ipInfoMode, mtrColumns...) {
+	presentation := mtrTUIOptions{NoSummary: *mtrFlags.noSummary, PacketSize: effectivePacketSize, DotServer: *dot}
+	if maybeRunMTRMode(mtrModes, method, conf, queriesExplicit, *numMeasurements, ttlTimeExplicit, *ttlInterval, domain, *dataOrigin, *showIPs, *ipInfoMode, presentation, mtrColumns...) {
 		return
 	}
 	if err := writeIgnoredTraceOutputWarning(os.Stderr, outputMode, resolvedOutputPath); err != nil {

--- a/cmd/mtr_column_editor.go
+++ b/cmd/mtr_column_editor.go
@@ -112,8 +112,12 @@ func (k *mtrKeyInput) feed(u *mtrUI, b byte, now time.Time) bool {
 		return false
 	}
 	k.expireEscape(u, now)
+	if k.parser.state == mtrStateGround && u.isMTRHelpActive() && (b == 'q' || b == 'Q') {
+		return u.applyInputAction(mtrActionQuit)
+	}
 	editing := u.isMTREditing()
 	k.parser.trackPaste = editing
+	k.parser.trackArrows = u.isMTRDialogActive()
 	if k.parser.state == mtrStateGround && b != 27 && editing {
 		u.editMTRInput(b, false)
 	} else {
@@ -137,7 +141,7 @@ func (k *mtrKeyInput) feed(u *mtrUI, b byte, now time.Time) bool {
 
 func (k *mtrKeyInput) feedPaste(u *mtrUI, b byte) {
 	const end = "\x1b[201~"
-	k.pasteEnd += string(b)
+	k.pasteEnd += string([]byte{b})
 	for k.pasteEnd != "" && !strings.HasPrefix(end, k.pasteEnd) {
 		u.editMTRInput(k.pasteEnd[0], true)
 		k.pasteEnd = k.pasteEnd[1:]
@@ -149,6 +153,9 @@ func (k *mtrKeyInput) feedPaste(u *mtrUI, b byte) {
 }
 
 func (u *mtrUI) applyInputAction(action mtrInputAction) bool {
+	if action != mtrActionQuit && u.applyMTRDialogAction(action) {
+		return false
+	}
 	if u.replay != nil && u.applyReplayAction(action) {
 		return false
 	}
@@ -176,6 +183,10 @@ func (u *mtrUI) applyInputAction(action mtrInputAction) bool {
 		u.CycleHistoryChartMode()
 	case mtrActionColumns:
 		u.openColumnEditor()
+	case mtrActionSave:
+		u.openSnapshotDialog()
+	case mtrActionHelp:
+		u.openHelpDialog()
 	}
 	return false
 }

--- a/cmd/mtr_json_run.go
+++ b/cmd/mtr_json_run.go
@@ -37,6 +37,7 @@ type mtrJSONOptions struct {
 	PrepareAsync       bool
 	CompactReport      bool
 	HumanOutput        bool
+	NoSummary          bool
 	OnEvent            func(trace.MTRSessionEvent) error
 }
 

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nxtrace/NTrace-core/config"
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
 	"github.com/nxtrace/NTrace-core/ipgeo"
 	"github.com/nxtrace/NTrace-core/printer"
 	"github.com/nxtrace/NTrace-core/trace"
@@ -49,7 +50,7 @@ func checkMTRConflicts(flags map[string]bool) (conflict string, ok bool) {
 // runMTRTUI 执行 MTR 交互式 TUI 模式。
 // 当 stdin 为 TTY 时启用全屏 TUI（备用屏幕、按键控制）；
 // 非 TTY 时降级为简单表格刷新。
-func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int, onEvent func(trace.MTRSessionEvent) error, columns ...printer.MTRColumn) error {
+func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPerHop int, domain string, dataOrigin string, showIPs bool, initialDisplayMode int, onEvent func(trace.MTRSessionEvent) error, options mtrTUIOptions, columns ...printer.MTRColumn) (runErr error) {
 	if hopIntervalMs <= 0 {
 		hopIntervalMs = 1000
 	}
@@ -62,14 +63,6 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 	// 初始化 TUI 控制器
 	ui := newMTRUI(cancel, initialDisplayMode)
 	ui.columns = append([]printer.MTRColumn(nil), columns...)
-	ui.Enter()
-	defer ui.Leave()
-
-	// 按键读取协程（非 TTY 时内部 no-op）
-	keysCtx, stopKeys := context.WithCancel(ctx)
-	keysDone := make(chan struct{})
-	go func() { defer close(keysDone); ui.ReadKeysLoop(keysCtx) }()
-	defer func() { stopKeys(); <-keysDone }()
 
 	startTime := time.Now()
 	target := conf.DstIP.String()
@@ -88,9 +81,49 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 	}
 
 	roundConf := normalizeMTRTraceConfig(conf)
+	snapshots := &mtrLiveSnapshots{start: startTime, session: mtrsession.Session{
+		Version: config.Version, Target: domain, ResolvedIP: target, Protocol: string(method), StartedAt: startTime.UTC(),
+		SourceHost: srcHost, SourceIP: srcIP,
+		EffectiveParameters: buildMTRSnapshotParameters(method, roundConf, hopIntervalMs, maxPerHop, dataOrigin, options),
+	}}
+	if snapshots.session.Target == "" {
+		snapshots.session.Target = target
+	}
+	ui.captureSnapshot = func() *printer.MTRSnapshot { return captureMTRDisplay(&snapshots.store, ui, showIPs) }
+	var probeErr error
+	ui.Enter()
+	defer func() {
+		ui.Leave()
+		if err := ui.closeSnapshotSaver(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		if ui.IsTTY() && !options.NoSummary {
+			summaryErr := probeErr
+			if summaryErr == nil {
+				summaryErr = context.Cause(ctx)
+			}
+			if err := writeMTRExitSummary(os.Stdout, ui.captureSnapshot(), summaryErr); err != nil {
+				fmt.Fprintf(os.Stderr, "write MTR summary: %v\n", err)
+			}
+		}
+	}()
+	keysCtx, stopKeys := context.WithCancel(ctx)
+	keysDone := make(chan struct{})
+	go func() { defer close(keysDone); ui.ReadKeysLoop(keysCtx) }()
+	defer func() { stopKeys(); <-keysDone }()
 
 	opts := buildMTRInteractiveOptions(ui, hopIntervalMs, maxPerHop)
 	opts.OnEvent = onEvent
+	if ui.IsTTY() {
+		opts.OnEvent = func(event trace.MTRSessionEvent) error {
+			snapshots.event(event)
+			if onEvent != nil {
+				return onEvent(event)
+			}
+			return nil
+		}
+		opts.OnPathEnd = func(reason *trace.StopReason) { snapshots.pathEnd = copyMTRPathEnd(reason) }
+	}
 	history := attachMTRHistoryIfTTY(ui, &opts)
 
 	// TTY 模式下使用 TUI 渲染器 + 暂停支持，非 TTY 使用简单表格
@@ -99,16 +132,21 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		opts.IsPaused = ui.IsPaused
 		var frameColumns []printer.MTRColumn
 		var frameEditor printer.MTRColumnEditor
-		render := printer.MTRTUIPrinter(target, domain, target, config.Version, startTime,
+		var frameSave printer.MTRSaveDialog
+		var frameHelp printer.MTRHelpDialog
+		render := printer.MTRTUIPrinterWithDialogs(target, domain, target, config.Version, startTime,
 			srcHost, srcIP, lang, func() string { return buildAPIInfo(dataOrigin) }, showIPs, ui.IsPaused,
 			ui.CurrentDisplayMode, ui.CurrentNameMode, ui.IsMPLSDisabled,
-			ui.IsHistoryMode, ui.CurrentHistoryChartMode, history.Snapshot, func() ([]printer.MTRColumn, printer.MTRColumnEditor) { return frameColumns, frameEditor })
+			ui.IsHistoryMode, ui.CurrentHistoryChartMode, history.Snapshot, func() ([]printer.MTRColumn, printer.MTRColumnEditor) { return frameColumns, frameEditor },
+			func() (printer.MTRSaveDialog, printer.MTRHelpDialog) { return frameSave, frameHelp })
 		pasteEnabled := false
 		var stopRedraw func()
 		onSnapshot, stopRedraw = startMTRRedraw(ui.redraw, func() (int, int) { w, h, _ := term.GetSize(int(os.Stdout.Fd())); return w, h }, func(n int, stats []trace.MTRHopStat) {
 			frameColumns, frameEditor = ui.columnSnapshot()
-			if frameEditor.Active != pasteEnabled {
-				pasteEnabled = frameEditor.Active
+			frameSave, frameHelp = ui.dialogSnapshot()
+			editing := frameEditor.Active || frameSave.Active || frameHelp.Active
+			if editing != pasteEnabled {
+				pasteEnabled = editing
 				if pasteEnabled {
 					_, _ = fmt.Fprint(os.Stdout, "\033[?2004h")
 				} else {
@@ -117,6 +155,11 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 			}
 			render(n, stats)
 		})
+		displaySnapshot := onSnapshot
+		onSnapshot = func(n int, stats []trace.MTRHopStat) {
+			snapshots.snapshot(stats)
+			displaySnapshot(n, stats)
+		}
 		defer stopRedraw()
 	} else {
 		onSnapshot = func(iteration int, stats []trace.MTRHopStat) {
@@ -124,7 +167,8 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 		}
 	}
 
-	return mtrRunError(ctx, trace.RunMTR(ctx, method, roundConf, opts, onSnapshot))
+	probeErr = trace.RunMTR(ctx, method, roundConf, opts, onSnapshot)
+	return mtrRunError(ctx, probeErr)
 }
 
 func buildMTRInteractiveOptions(ui *mtrUI, hopIntervalMs int, maxPerHop int) trace.MTROptions {

--- a/cmd/mtr_mode.go
+++ b/cmd/mtr_mode.go
@@ -61,8 +61,7 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 	defer cancel()
 
 	// 初始化 TUI 控制器
-	ui := newMTRUI(cancel, initialDisplayMode)
-	ui.columns = append([]printer.MTRColumn(nil), columns...)
+	ui := newMTRTraceUI(cancel, initialDisplayMode, conf.DisableMPLS, columns)
 
 	startTime := time.Now()
 	target := conf.DstIP.String()
@@ -169,6 +168,13 @@ func runMTRTUI(method trace.Method, conf trace.Config, hopIntervalMs int, maxPer
 
 	probeErr = trace.RunMTR(ctx, method, roundConf, opts, onSnapshot)
 	return mtrRunError(ctx, probeErr)
+}
+
+func newMTRTraceUI(cancel context.CancelFunc, initialDisplayMode int, disableMPLS bool, columns []printer.MTRColumn) *mtrUI {
+	ui := newMTRUI(cancel, initialDisplayMode)
+	ui.columns = append([]printer.MTRColumn(nil), columns...)
+	ui.disableMPLS.Store(disableMPLS)
+	return ui
 }
 
 func buildMTRInteractiveOptions(ui *mtrUI, hopIntervalMs int, maxPerHop int) trace.MTROptions {

--- a/cmd/mtr_record.go
+++ b/cmd/mtr_record.go
@@ -168,7 +168,8 @@ func runMTRRecorded(ctx context.Context, opts mtrJSONOptions, modes effectiveMTR
 		case mtrRunReport:
 			err = runMTRReport(opts.Method, opts.Config, opts.HopIntervalMs, opts.MaxPerHop, opts.Target, opts.DataProvider, modes.wide, showIPs, recording.event, columns...)
 		default:
-			err = runMTRTUI(opts.Method, opts.Config, opts.HopIntervalMs, opts.MaxPerHop, opts.Target, opts.DataProvider, showIPs, hostMode, recording.event, columns...)
+			err = runMTRTUI(opts.Method, opts.Config, opts.HopIntervalMs, opts.MaxPerHop, opts.Target, opts.DataProvider, showIPs, hostMode, recording.event,
+				mtrTUIOptions{NoSummary: opts.NoSummary, Parameters: out.report.EffectiveParameters}, columns...)
 		}
 	}
 	if cause := context.Cause(ctx); cause != nil && (err == nil || errors.Is(err, context.Canceled)) {

--- a/cmd/mtr_replay.go
+++ b/cmd/mtr_replay.go
@@ -23,6 +23,7 @@ type mtrReplayOptions struct {
 	report, wide, json, noColor, showIPs bool
 	columns, language                    string
 	hostMode                             int
+	noSummary                            bool
 	explicit                             map[string]bool
 }
 
@@ -106,6 +107,7 @@ func maybeRunMTRReplayMode(args []string, stdout, stderr io.Writer) (bool, int) 
 	}
 	fs.BoolVar(&o.showIPs, "show-ips", false, "Show PTR and IP together")
 	fs.StringVar(&o.columns, "mtr-columns", "", "Select text statistic columns")
+	fs.BoolVar(&o.noSummary, "no-mtr-summary", false, "Suppress the summary printed after leaving the MTR TUI")
 	ordered, err := doctorArgs(fs, normalizeMTRReplayArgs(fs, args))
 	if err == nil {
 		err = fs.Parse(ordered)
@@ -226,7 +228,7 @@ func runMTRReplay(ctx context.Context, opts mtrReplayOptions, stdout, stderr io.
 		return printer.WriteMTRReplayReport(stdout, sanitizeMTRReplayStats(loaded.state.Snapshot().Stats), printer.MTRReportOptions{Columns: header.Columns, StartTime: header.StartTime, SrcHost: header.SrcHost, Wide: wide, ShowIPs: header.ShowIPs, Lang: header.Lang})
 	}
 	applyColorMode(opts.noColor)
-	return runMTRReplayTUI(ctx, r, loaded, header, duration, complete, stdout)
+	return runMTRReplayTUI(ctx, r, loaded, header, duration, complete, opts.noSummary, stdout)
 }
 
 func mtrReplayHeader(session *mtrsession.Session, opts mtrReplayOptions) (printer.MTRTUIHeader, error) {

--- a/cmd/mtr_replay_exit_test.go
+++ b/cmd/mtr_replay_exit_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+// advance checks cancellation between records, so this accepts one pending
+// record and then cancels without depending on a scheduler timing window.
+type replayCancelAfterRecord struct {
+	context.Context
+	checks int
+}
+
+func (c *replayCancelAfterRecord) Err() error {
+	c.checks++
+	if c.checks > 1 {
+		return context.Canceled
+	}
+	return nil
+}
+
+type replayExitFrameWriter struct {
+	bytes.Buffer
+	afterFrame func() error
+}
+
+func (w *replayExitFrameWriter) Write(data []byte) (int, error) {
+	n, err := w.Buffer.Write(data)
+	if w.afterFrame != nil && bytes.Contains(data, []byte("\x1b[H\x1b[2J")) {
+		callback := w.afterFrame
+		w.afterFrame = nil
+		return n, callback()
+	}
+	return n, err
+}
+
+func TestMTRReplayExitSummaryCommitsCancelledAdvance(t *testing.T) {
+	for _, invalidRecord := range []bool{false, true} {
+		name := "cancelled_after_probe"
+		if invalidRecord {
+			name = "failed_record_keeps_published_position"
+		}
+		t.Run(name, func(t *testing.T) {
+			r, err := mtrsession.OpenReader(replayFixture(t, time.Now(), true))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = r.Close() }()
+			current, err := readMTRReplay(t.Context(), r, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			header, err := mtrReplayHeader(current.session, mtrReplayOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var advanceErr error
+			output := &replayExitFrameWriter{}
+			output.afterFrame = func() error {
+				// The first frame already published cursor zero. Simulate an
+				// advance that stops before a second frame can be published.
+				if invalidRecord {
+					current.pending = &mtrsession.Record{ElapsedNS: int64(time.Second),
+						MTRSessionEvent: trace.MTRSessionEvent{Type: trace.MTRSessionMetadataEvent,
+							Metadata: &trace.MTRSessionMetadata{IP: "192.0.2.99", Host: "unseen.invalid"}}}
+				}
+				advanceErr = current.advance(&replayCancelAfterRecord{Context: ctx}, r, 7*time.Second)
+				cancel()
+				if invalidRecord {
+					return advanceErr
+				}
+				return nil
+			}
+			runErr := runMTRReplayTUI(ctx, r, current, header, 7*time.Second, true, false, output)
+			if invalidRecord {
+				if advanceErr == nil || errors.Is(advanceErr, context.Canceled) || !errors.Is(runErr, advanceErr) {
+					t.Fatalf("advance=%v run=%v, want the original invalid-record error", advanceErr, runErr)
+				}
+			} else if !errors.Is(advanceErr, context.Canceled) || runErr != nil {
+				t.Fatalf("advance=%v run=%v, want cancellation without a new error", advanceErr, runErr)
+			}
+			if current.cursor != time.Second {
+				t.Fatalf("advance did not reach the intermediate cursor: %s", current.cursor)
+			}
+			_, summary, found := strings.Cut(output.String(), "NextTrace MTR snapshot\n")
+			if !found {
+				t.Fatalf("exit summary missing: %q", output.String())
+			}
+			wantCursor := "Replay: 00:00:01.000 / 00:00:07.000"
+			if invalidRecord {
+				wantCursor = "Replay: 00:00:00.000 / 00:00:07.000"
+			}
+			if !strings.Contains(summary, wantCursor) {
+				t.Fatalf("wrong exit position; want %q:\n%s", wantCursor, summary)
+			}
+			if invalidRecord != strings.Contains(summary, "No probe statistics.") {
+				t.Fatalf("statistics do not match the exit position:\n%s", summary)
+			}
+			if !invalidRecord && !strings.Contains(summary, "before.invalid") {
+				t.Fatalf("accepted probe missing from exit summary:\n%s", summary)
+			}
+		})
+	}
+}

--- a/cmd/mtr_replay_input.go
+++ b/cmd/mtr_replay_input.go
@@ -44,12 +44,18 @@ func (r *mtrReplayControls) send(command mtrReplayCommand) {
 }
 
 func (u *mtrUI) isMTREditing() bool {
+	if u.isMTRDialogActive() {
+		return true
+	}
 	u.columnsMu.Lock()
 	defer u.columnsMu.Unlock()
 	return u.columnEditor.Active || u.replayEditor.Active
 }
 
 func (u *mtrUI) editMTRInput(b byte, paste bool) {
+	if u.editMTRDialog(b, paste) {
+		return
+	}
 	u.columnsMu.Lock()
 	replay := u.replayEditor.Active
 	u.columnsMu.Unlock()

--- a/cmd/mtr_replay_tui.go
+++ b/cmd/mtr_replay_tui.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 	"unicode"
@@ -36,7 +37,7 @@ func (w *mtrReplayOutput) Write(data []byte) (int, error) {
 	return n, err
 }
 
-func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current *mtrReplayCursor, header printer.MTRTUIHeader, duration time.Duration, complete bool, stdout io.Writer) error {
+func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current *mtrReplayCursor, header printer.MTRTUIHeader, duration time.Duration, complete, noSummary bool, stdout io.Writer) (runErr error) {
 	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 	ui := newMTRUI(cancel, header.DisplayMode)
@@ -46,8 +47,27 @@ func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current 
 	ui.paused.Store(true)
 	ui.replay = &mtrReplayControls{commands: make(chan mtrReplayCommand, 1), duration: duration}
 	ui.replay.cursor.Store(int64(current.cursor))
+	var snapshots mtrSnapshotStore
+	publishMTRReplaySnapshot(&snapshots, current, duration, complete, false)
+	ui.captureSnapshot = func() *printer.MTRSnapshot {
+		snapshot := captureMTRDisplay(&snapshots, ui, header.ShowIPs)
+		if snapshot != nil && snapshot.Session != nil && snapshot.Session.EffectiveParameters != nil {
+			snapshot.Session.EffectiveParameters.Language = header.Lang
+		}
+		return snapshot
+	}
 	ui.Enter()
-	defer ui.Leave()
+	defer func() {
+		ui.Leave()
+		if err := ui.closeSnapshotSaver(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		if !noSummary {
+			if err := writeMTRExitSummary(stdout, ui.captureSnapshot(), runErr); err != nil {
+				fmt.Fprintf(os.Stderr, "write MTR summary: %v\n", err)
+			}
+		}
+	}()
 	keysDone := make(chan struct{})
 	go func() { defer close(keysDone); ui.ReadKeysLoop(ctx) }()
 	defer func() { cancel(); <-keysDone }()
@@ -91,8 +111,9 @@ func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current 
 		h.Columns = append([]printer.MTRColumn(nil), ui.columns...)
 		h.ColumnEditor = ui.columnEditor
 		h.ReplayEditor = ui.replayEditor
-		editing := h.ColumnEditor.Active || h.ReplayEditor.Active
 		ui.columnsMu.Unlock()
+		h.SaveDialog, h.HelpDialog = ui.dialogSnapshot()
+		editing := h.ColumnEditor.Active || h.ReplayEditor.Active || h.SaveDialog.Active || h.HelpDialog.Active
 		// The sink retains the first error; render returns it after the frame.
 		if editing {
 			_, _ = fmt.Fprint(output, "\033[?2004h")
@@ -101,6 +122,7 @@ func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current 
 		}
 		snapshot := current.state.Snapshot()
 		h.Iteration = snapshot.Iteration
+		publishMTRReplaySnapshot(&snapshots, current, duration, complete, playing && !ui.IsPaused())
 		printer.MTRTUIRender(output, h, sanitizeMTRReplayStats(snapshot.Stats))
 		return output.err
 	}

--- a/cmd/mtr_replay_tui.go
+++ b/cmd/mtr_replay_tui.go
@@ -48,6 +48,7 @@ func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current 
 	ui.replay = &mtrReplayControls{commands: make(chan mtrReplayCommand, 1), duration: duration}
 	ui.replay.cursor.Store(int64(current.cursor))
 	var snapshots mtrSnapshotStore
+	playing := false
 	publishMTRReplaySnapshot(&snapshots, current, duration, complete, false)
 	ui.captureSnapshot = func() *printer.MTRSnapshot {
 		snapshot := captureMTRDisplay(&snapshots, ui, header.ShowIPs)
@@ -63,6 +64,12 @@ func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current 
 			fmt.Fprintln(os.Stderr, err)
 		}
 		if !noSummary {
+			if runErr == nil {
+				// Cancellation can stop advance after an accepted record but
+				// before rendering. Failed records may have moved the cursor
+				// without applying their state, so retain the published view on errors.
+				publishMTRReplaySnapshot(&snapshots, current, duration, complete, playing && !ui.IsPaused())
+			}
 			if err := writeMTRExitSummary(stdout, ui.captureSnapshot(), runErr); err != nil {
 				fmt.Fprintf(os.Stderr, "write MTR summary: %v\n", err)
 			}
@@ -74,7 +81,6 @@ func runMTRReplayTUI(parent context.Context, reader *mtrsession.Reader, current 
 	var seekDone chan mtrReplaySeekResult
 	var stopSeek context.CancelFunc
 	var queuedSeek *time.Duration
-	playing := false
 	output := &mtrReplayOutput{w: stdout}
 	baseCursor, baseTime := current.cursor, time.Now()
 	beginSeek := func(at time.Duration) {

--- a/cmd/mtr_snapshot.go
+++ b/cmd/mtr_snapshot.go
@@ -130,8 +130,8 @@ func captureMTRDisplay(store *mtrSnapshotStore, ui *mtrUI, showIPs bool) *printe
 	if snapshot == nil || snapshot.Session == nil {
 		return snapshot
 	}
-	if snapshot.Source == "live" {
-		// Pause can change after the last reply, without another probe snapshot.
+	if snapshot.Source == "live" || snapshot.Source == "replay" {
+		// Controls can change before the next probe snapshot or replay render.
 		// Match the current TUI control state while retaining the data timestamp.
 		snapshot.State = "running"
 		if ui.IsPaused() {

--- a/cmd/mtr_snapshot.go
+++ b/cmd/mtr_snapshot.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+type mtrTUIOptions struct {
+	NoSummary  bool
+	PacketSize int
+	DotServer  string
+	Parameters *mtrsession.Parameters
+}
+
+// Published snapshots are immutable. Only the probe callback (or replay loop)
+// writes; input and rendering may independently capture the last committed view.
+type mtrSnapshotStore struct {
+	mu     sync.Mutex
+	latest *printer.MTRSnapshot
+}
+
+func (s *mtrSnapshotStore) publish(snapshot printer.MTRSnapshot) {
+	next := cloneMTRSnapshot(&snapshot)
+	s.mu.Lock()
+	s.latest = next
+	s.mu.Unlock()
+}
+
+func (s *mtrSnapshotStore) capture() *printer.MTRSnapshot {
+	s.mu.Lock()
+	latest := s.latest
+	s.mu.Unlock()
+	return cloneMTRSnapshot(latest)
+}
+
+func cloneMTRSnapshot(snapshot *printer.MTRSnapshot) *printer.MTRSnapshot {
+	if snapshot == nil {
+		return nil
+	}
+	copy := *snapshot
+	copy.Stats = cloneMTRDisplayStats(snapshot.Stats)
+	for i := range copy.Stats {
+		if geo := copy.Stats[i].Geo; geo != nil && geo.Router != nil {
+			routers := make(map[string][]string, len(geo.Router))
+			for name, addresses := range geo.Router {
+				routers[name] = slices.Clone(addresses)
+			}
+			geo.Router = routers
+		}
+	}
+	if copy.Stats == nil {
+		copy.Stats = []trace.MTRHopStat{}
+	}
+	copy.PathEnd = copyMTRPathEnd(snapshot.PathEnd)
+	if snapshot.Session != nil {
+		session := *snapshot.Session
+		copy.Session = &session
+		if p := session.EffectiveParameters; p != nil {
+			params := *p
+			params.Port = cloneMTRInt(p.Port)
+			params.SourcePort = cloneMTRInt(p.SourcePort)
+			params.ICMPMode = cloneMTRInt(p.ICMPMode)
+			if p.FWMark != nil {
+				mark := *p.FWMark
+				params.FWMark = &mark
+			}
+			session.EffectiveParameters = &params
+		}
+	}
+	if snapshot.Replay != nil {
+		replay := *snapshot.Replay
+		copy.Replay = &replay
+	}
+	return &copy
+}
+
+func cloneMTRInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	return ptrInt(*value)
+}
+
+// Event and snapshot callbacks execute serially in scheduler order. Path and
+// generation changes become visible to readers only with the next statistics.
+type mtrLiveSnapshots struct {
+	store      mtrSnapshotStore
+	session    mtrsession.Session
+	start      time.Time
+	pathEnd    *trace.StopReason
+	generation uint64
+	paused     bool
+}
+
+func (s *mtrLiveSnapshots) event(event trace.MTRSessionEvent) {
+	s.generation = event.Generation
+	switch event.Type {
+	case trace.MTRSessionResetEvent:
+		s.pathEnd = nil
+	case trace.MTRSessionPauseEvent:
+		s.paused = true
+	case trace.MTRSessionResumeEvent:
+		s.paused = false
+	}
+}
+
+func (s *mtrLiveSnapshots) snapshot(stats []trace.MTRHopStat) {
+	now := time.Now()
+	state := "running"
+	if s.paused {
+		state = "paused"
+	}
+	s.store.publish(printer.MTRSnapshot{
+		SchemaVersion: 1, Type: "mtr_snapshot", Source: "live", CapturedAt: now.UTC(),
+		ElapsedNS: max(int64(0), now.Sub(s.start).Nanoseconds()), Generation: s.generation,
+		State: state, Session: &s.session, PathEnd: s.pathEnd, Stats: stats,
+	})
+}
+
+func captureMTRDisplay(store *mtrSnapshotStore, ui *mtrUI, showIPs bool) *printer.MTRSnapshot {
+	snapshot := store.capture()
+	if snapshot == nil || snapshot.Session == nil {
+		return snapshot
+	}
+	if snapshot.Source == "live" {
+		// Pause can change after the last reply, without another probe snapshot.
+		// Match the current TUI control state while retaining the data timestamp.
+		snapshot.State = "running"
+		if ui.IsPaused() {
+			snapshot.State = "paused"
+		}
+	}
+	columns, _ := ui.columnSnapshot()
+	if columns == nil {
+		columns = printer.DefaultMTRColumns()
+	}
+	snapshot.Session.Display = mtrsession.DisplayParameters{
+		HostMode: ui.CurrentDisplayMode(), HostNameMode: ui.CurrentNameMode(),
+		ShowIPs: showIPs, ShowMPLS: !ui.IsMPLSDisabled(), Columns: printer.MTRColumnNames(columns),
+	}
+	return snapshot
+}
+
+func buildMTRSnapshotParameters(method trace.Method, conf trace.Config, interval, count int, provider string, options mtrTUIOptions) *mtrsession.Parameters {
+	if options.Parameters != nil {
+		return options.Parameters
+	}
+	params := &mtrsession.Parameters{
+		MaxPerHop: count, HopIntervalMs: interval, TimeoutMs: conf.Timeout.Milliseconds(),
+		BeginHop: conf.BeginHop, MaxHops: conf.MaxHops, ParallelRequests: conf.ParallelRequests,
+		SourceAddress: conf.SrcAddr, SourceDevice: conf.SourceDevice,
+		PacketSize: options.PacketSize, RandomPacketSize: conf.RandomPacketSize, TOS: conf.TOS,
+		DataProvider: provider, Language: conf.Lang, DotServer: options.DotServer,
+		RDNS: conf.RDNS, AlwaysWaitRDNS: conf.RDNS && conf.AlwaysWaitRDNS,
+		DisableMPLS: conf.DisableMPLS, DN42: conf.DN42,
+	}
+	if conf.FWMarkSet {
+		mark := conf.FWMark
+		params.FWMark = &mark
+	}
+	if method != trace.ICMPTrace {
+		params.Port, params.SourcePort = ptrInt(conf.DstPort), ptrInt(conf.SrcPort)
+	}
+	if conf.OSType == 2 {
+		params.ICMPMode = ptrInt(conf.ICMPMode)
+	}
+	return params
+}
+
+func publishMTRReplaySnapshot(store *mtrSnapshotStore, current *mtrReplayCursor, duration time.Duration, complete, playing bool) {
+	state := "paused"
+	if playing {
+		state = "running"
+	}
+	store.publish(printer.MTRSnapshot{
+		SchemaVersion: 1, Type: "mtr_snapshot", Source: "replay",
+		CapturedAt: time.Now().UTC(), ElapsedNS: int64(current.cursor),
+		Generation: current.state.Generation(), State: state, Session: current.session,
+		PathEnd: current.state.PathEnd(), Stats: current.state.Snapshot().Stats,
+		Replay: &printer.MTRSnapshotReplay{CursorNS: int64(current.cursor), DurationNS: int64(duration),
+			RecordingComplete: complete, RecordedPaused: current.state.Paused()},
+	})
+}
+
+func writeMTRExitSummary(w io.Writer, snapshot *printer.MTRSnapshot, runErr error) error {
+	if snapshot == nil {
+		return nil
+	}
+	if snapshot.Source == "live" {
+		snapshot.State = "completed"
+		if runErr != nil {
+			snapshot.State = "error"
+			var signal *mtrJSONSignal
+			if errors.Is(runErr, context.Canceled) || errors.As(runErr, &signal) {
+				snapshot.State = "interrupted"
+			}
+		}
+	}
+	return printer.WriteMTRSnapshot(w, *snapshot, "txt")
+}

--- a/cmd/mtr_snapshot_test.go
+++ b/cmd/mtr_snapshot_test.go
@@ -89,6 +89,36 @@ func TestMTRSnapshotUsesCurrentDisplayWithoutChangingSession(t *testing.T) {
 	}
 }
 
+func TestMTRSnapshotHonorsInitialMPLSSettingAndRuntimeToggle(t *testing.T) {
+	for _, disabled := range []bool{false, true} {
+		conf := trace.Config{DisableMPLS: disabled}
+		ui := newMTRTraceUI(nil, 4, conf.DisableMPLS, []printer.MTRColumn{printer.MTRColumnLoss})
+		var store mtrSnapshotStore
+		store.publish(printer.MTRSnapshot{Session: &mtrsession.Session{
+			EffectiveParameters: &mtrsession.Parameters{DisableMPLS: conf.DisableMPLS},
+		}})
+		initial := captureMTRDisplay(&store, ui, false)
+		if ui.IsMPLSDisabled() != disabled || initial.Session.Display.ShowMPLS == disabled {
+			t.Fatalf("disable_mpls=%v: initial display=%+v", disabled, initial.Session.Display)
+		}
+		var keys mtrKeyInput
+		for _, key := range []string{"e", "E"} {
+			feedMTRKeys(ui, &keys, key)
+			snapshot := captureMTRDisplay(&store, ui, false)
+			wantShow := disabled
+			if key == "E" {
+				wantShow = !disabled
+			}
+			if snapshot.Session.Display.ShowMPLS != wantShow {
+				t.Fatalf("disable_mpls=%v after %s: display=%+v", disabled, key, snapshot.Session.Display)
+			}
+			if snapshot.Session.EffectiveParameters.DisableMPLS != disabled || initial.Session.Display.ShowMPLS == disabled {
+				t.Fatal("display toggle changed probe settings or an earlier snapshot")
+			}
+		}
+	}
+}
+
 func TestMTRSnapshotPauseWithoutAnotherProbe(t *testing.T) {
 	var store mtrSnapshotStore
 	store.publish(printer.MTRSnapshot{Source: "live", State: "running", Session: &mtrsession.Session{}})

--- a/cmd/mtr_snapshot_test.go
+++ b/cmd/mtr_snapshot_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/akamensky/argparse"
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func TestMTRSnapshotPublishesPathAndResetWithStatistics(t *testing.T) {
+	live := mtrLiveSnapshots{start: time.Now(), session: mtrsession.Session{Target: "example.com"}}
+	stats := []trace.MTRHopStat{{TTL: 3, IP: "192.0.2.3", Snt: 4,
+		Geo: &ipgeo.IPGeoData{Owner: "original", Router: map[string][]string{"router": {"original"}, "empty": {}, "null": nil}}, MPLS: []string{"label"}}}
+	live.snapshot(stats)
+	frozen := live.store.capture()
+	live.pathEnd = &trace.StopReason{Reason: trace.StopReasonDestination, Hop: 2}
+	if next := live.store.capture(); next.PathEnd != nil || next.Stats[0].TTL != 3 {
+		t.Fatal("path was published before its matching statistics")
+	}
+	live.snapshot([]trace.MTRHopStat{{TTL: 2, IP: "192.0.2.2", Snt: 1}})
+	if next := live.store.capture(); next.PathEnd.Hop != 2 || next.Stats[0].TTL != 2 {
+		t.Fatalf("inconsistent path snapshot: %+v", next)
+	}
+	live.event(trace.MTRSessionEvent{Type: trace.MTRSessionResetEvent, Generation: 1})
+	if next := live.store.capture(); next.Generation != 0 || next.PathEnd == nil {
+		t.Fatal("reset was published before its matching statistics")
+	}
+	live.snapshot(nil)
+	if next := live.store.capture(); next.Generation != 1 || next.PathEnd != nil || next.Stats == nil || len(next.Stats) != 0 {
+		t.Fatalf("invalid reset snapshot: %+v", next)
+	}
+	stats[0].Geo.Owner, stats[0].MPLS[0] = "changed", "changed"
+	stats[0].Geo.Router["router"][0] = "changed"
+	if frozen.Stats[0].Geo.Owner != "original" || frozen.Stats[0].MPLS[0] != "label" || frozen.Stats[0].Snt != 4 {
+		t.Fatal("captured snapshot changed with later metadata")
+	}
+	if frozen.Stats[0].Geo.Router["router"][0] != "original" {
+		t.Fatal("captured snapshot shares nested router metadata")
+	}
+	if frozen.Stats[0].Geo.Router["empty"] == nil || frozen.Stats[0].Geo.Router["null"] != nil {
+		t.Fatal("captured snapshot changed empty and null router values")
+	}
+}
+
+func TestMTRSnapshotConcurrentCaptureOwnsItsData(t *testing.T) {
+	var store mtrSnapshotStore
+	var wg sync.WaitGroup
+	for worker := 0; worker < 4; worker++ {
+		wg.Go(func() {
+			for i := 0; i < 100; i++ {
+				store.publish(printer.MTRSnapshot{Session: &mtrsession.Session{
+					EffectiveParameters: &mtrsession.Parameters{Port: ptrInt(443)}},
+					Stats: []trace.MTRHopStat{{Snt: 1, Geo: &ipgeo.IPGeoData{Owner: "owner"}}}})
+				snapshot := store.capture()
+				*snapshot.Session.EffectiveParameters.Port = 80
+				snapshot.Stats[0].Geo.Owner = "mutated"
+			}
+		})
+	}
+	wg.Wait()
+	got := store.capture()
+	if *got.Session.EffectiveParameters.Port != 443 || got.Stats[0].Geo.Owner != "owner" {
+		t.Fatal("reader modified the published snapshot")
+	}
+}
+
+func TestMTRSnapshotUsesCurrentDisplayWithoutChangingSession(t *testing.T) {
+	var store mtrSnapshotStore
+	store.publish(printer.MTRSnapshot{Session: &mtrsession.Session{Display: mtrsession.DisplayParameters{HostMode: 0}}})
+	ui := newMTRUI(nil, 4)
+	ui.columns = []printer.MTRColumn{printer.MTRColumnLoss, printer.MTRColumnSpace, printer.MTRColumnJitter}
+	ui.ToggleNameMode()
+	ui.ToggleMPLS()
+	got := captureMTRDisplay(&store, ui, true).Session.Display
+	if got.HostMode != 4 || got.HostNameMode != 1 || !got.ShowIPs || got.ShowMPLS || got.Columns != "loss,space,jitter" {
+		t.Fatalf("display=%+v", got)
+	}
+	if store.capture().Session.Display.HostMode != 0 {
+		t.Fatal("display capture changed the stored session")
+	}
+}
+
+func TestMTRSnapshotPauseWithoutAnotherProbe(t *testing.T) {
+	var store mtrSnapshotStore
+	store.publish(printer.MTRSnapshot{Source: "live", State: "running", Session: &mtrsession.Session{}})
+	ui := newMTRUI(nil, 0)
+	ui.paused.Store(true)
+	if got := captureMTRDisplay(&store, ui, false).State; got != "paused" {
+		t.Fatalf("state=%s after pause without a probe", got)
+	}
+	ui.paused.Store(false)
+	if got := captureMTRDisplay(&store, ui, false).State; got != "running" {
+		t.Fatalf("state=%s after resume without a probe", got)
+	}
+}
+
+func TestMTRReplaySnapshotRetainsPositionAndIncompleteState(t *testing.T) {
+	start := time.Now().Add(-time.Hour)
+	current := &mtrReplayCursor{session: &mtrsession.Session{StartedAt: start},
+		state: trace.NewMTRReplayState(false, 30), cursor: 2 * time.Second}
+	var store mtrSnapshotStore
+	publishMTRReplaySnapshot(&store, current, 10*time.Second, false, true)
+	snapshot := store.capture()
+	if snapshot.Source != "replay" || snapshot.State != "running" || snapshot.Replay.RecordingComplete || snapshot.Replay.CursorNS != int64(2*time.Second) || snapshot.Replay.DurationNS != int64(10*time.Second) {
+		t.Fatalf("snapshot=%+v replay=%+v", snapshot, snapshot.Replay)
+	}
+	if time.Since(snapshot.CapturedAt) > time.Second {
+		t.Fatal("capture time is the old recording timestamp")
+	}
+	var output bytes.Buffer
+	if err := printer.WriteMTRSnapshot(&output, *snapshot, "json"); err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(output.Bytes(), &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"ended_at", "end_reason", "end"} {
+		if _, ok := document[forbidden]; ok {
+			t.Fatalf("snapshot invents %s", forbidden)
+		}
+	}
+}
+
+func TestMTRExitSummaryRetainsInterruptionAndEmptyInitialization(t *testing.T) {
+	var output bytes.Buffer
+	if err := writeMTRExitSummary(&output, nil, context.Canceled); err != nil || output.Len() != 0 {
+		t.Fatal("initialization without a snapshot produced a summary")
+	}
+	snapshot := &printer.MTRSnapshot{Source: "live", Session: &mtrsession.Session{Target: "example.com"}}
+	if err := writeMTRExitSummary(&output, snapshot, context.Canceled); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output.String(), "interrupted") {
+		t.Fatalf("summary lost interruption: %s", output.String())
+	}
+}
+
+func TestNoMTRSummaryDoesNotSelectMode(t *testing.T) {
+	parser := argparse.NewParser(appBinName, "")
+	flags := registerMTRFlags(parser)
+	if err := parser.Parse([]string{appBinName, "--no-mtr-summary"}); err != nil {
+		t.Fatal(err)
+	}
+	if !*flags.noSummary || *flags.mtrMode || *flags.reportMode || *flags.wideMode {
+		t.Fatal("summary presentation flag selected a probe mode")
+	}
+	var out, diagnostic bytes.Buffer
+	handled, code := maybeRunMTRReplayMode([]string{"--mtr-replay", "--help", "--no-mtr-summary"}, &out, &diagnostic)
+	if !handled || code != 0 || !strings.Contains(out.String(), "no-mtr-summary") {
+		t.Fatalf("replay help: handled=%v code=%d stderr=%s", handled, code, &diagnostic)
+	}
+}

--- a/cmd/mtr_snapshot_ui.go
+++ b/cmd/mtr_snapshot_ui.go
@@ -82,9 +82,11 @@ func (u *mtrUI) applyMTRDialogAction(action mtrInputAction) bool {
 	u.dialogsMu.Lock()
 	defer u.dialogsMu.Unlock()
 	if u.helpDialog.Active {
-		width, height, err := term.GetSize(int(os.Stdout.Fd()))
-		if err != nil {
-			width, height = 80, 24
+		width, height := 80, 24
+		if u.terminalSize != nil {
+			width, height = u.terminalSize()
+		} else if w, h, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+			width, height = w, h
 		}
 		limit := printer.MTRHelpMaxOffset(u.replay != nil, width, height)
 		u.helpDialog.Offset = min(u.helpDialog.Offset, limit)

--- a/cmd/mtr_snapshot_ui.go
+++ b/cmd/mtr_snapshot_ui.go
@@ -1,0 +1,313 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/nxtrace/NTrace-core/printer"
+	"golang.org/x/term"
+)
+
+const mtrSnapshotPathLimit = 4096
+
+type mtrSnapshotJob struct {
+	path, format string
+	snapshot     *printer.MTRSnapshot
+}
+
+// dialogSnapshot is consumed by the renderer. A returned failure no longer
+// needs to be repeated after the alternate screen has been restored.
+func (u *mtrUI) dialogSnapshot() (printer.MTRSaveDialog, printer.MTRHelpDialog) {
+	u.columnsMu.Lock()
+	otherEditor := u.columnEditor.Active || u.replayEditor.Active
+	u.columnsMu.Unlock()
+	u.dialogsMu.Lock()
+	defer u.dialogsMu.Unlock()
+	if u.saveDialog.Error != "" && (u.saveDialog.Active || (!u.helpDialog.Active && !otherEditor)) {
+		u.snapshotError = nil
+	}
+	return u.saveDialog, u.helpDialog
+}
+
+func (u *mtrUI) isMTRDialogActive() bool {
+	u.dialogsMu.Lock()
+	defer u.dialogsMu.Unlock()
+	return u.saveDialog.Active || u.helpDialog.Active
+}
+
+func (u *mtrUI) isMTRHelpActive() bool {
+	u.dialogsMu.Lock()
+	defer u.dialogsMu.Unlock()
+	return u.helpDialog.Active
+}
+
+func (u *mtrUI) openSnapshotDialog() {
+	var snapshot *printer.MTRSnapshot
+	if u.captureSnapshot != nil {
+		snapshot = u.captureSnapshot()
+	}
+	u.dialogsMu.Lock()
+	defer u.dialogsMu.Unlock()
+	if u.snapshotClosed {
+		return
+	}
+	// An in-flight write retains its original snapshot even after Esc.
+	if u.saveDialog.Busy {
+		u.saveDialog.Active = true
+		return
+	}
+	u.saveSnapshot = snapshot
+	u.saveUTF8 = nil
+	u.saveDialog = printer.MTRSaveDialog{Active: true, Format: "txt"}
+	if snapshot == nil {
+		u.saveDialog.Error = "No snapshot available"
+		return
+	}
+	u.saveDialog.CapturedAt = snapshot.CapturedAt
+	u.saveDialog.Path = printer.DefaultMTRSnapshotFilename(*snapshot, "txt")
+}
+
+func (u *mtrUI) openHelpDialog() {
+	u.dialogsMu.Lock()
+	u.helpDialog = printer.MTRHelpDialog{Active: true}
+	u.dialogsMu.Unlock()
+}
+
+func (u *mtrUI) applyMTRDialogAction(action mtrInputAction) bool {
+	u.dialogsMu.Lock()
+	defer u.dialogsMu.Unlock()
+	if u.helpDialog.Active {
+		width, height, err := term.GetSize(int(os.Stdout.Fd()))
+		if err != nil {
+			width, height = 80, 24
+		}
+		limit := printer.MTRHelpMaxOffset(u.replay != nil, width, height)
+		u.helpDialog.Offset = min(u.helpDialog.Offset, limit)
+		switch action {
+		case mtrActionUp:
+			u.helpDialog.Offset = max(0, u.helpDialog.Offset-1)
+		case mtrActionDown:
+			u.helpDialog.Offset = min(limit, u.helpDialog.Offset+1)
+		}
+		return true
+	}
+	if u.saveDialog.Active {
+		if !u.saveDialog.Busy && u.saveDialog.Field == 0 {
+			switch action {
+			case mtrActionLeft:
+				u.cycleSnapshotFormat(-1)
+			case mtrActionRight:
+				u.cycleSnapshotFormat(1)
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (u *mtrUI) editMTRDialog(b byte, paste bool) bool {
+	u.dialogsMu.Lock()
+	defer u.dialogsMu.Unlock()
+	if u.helpDialog.Active {
+		if !paste && (b == '?' || b == 27) {
+			u.helpDialog.Active = false
+		}
+		return true
+	}
+	if !u.saveDialog.Active {
+		return false
+	}
+	if !paste && b == 27 {
+		u.saveDialog.Active = false
+		u.saveUTF8 = nil
+		return true
+	}
+	if u.saveDialog.Busy {
+		return true
+	}
+	if !paste {
+		switch b {
+		case '\t':
+			u.saveDialog.Field = 1 - u.saveDialog.Field
+			u.saveUTF8 = nil
+			return true
+		case '\r', '\n':
+			u.submitSnapshot()
+			return true
+		case ' ':
+			if u.saveDialog.Field == 0 {
+				u.cycleSnapshotFormat(1)
+				return true
+			}
+		}
+	}
+	if u.saveDialog.Field == 1 {
+		u.editSnapshotPath(b, paste)
+	}
+	return true
+}
+
+// The caller holds dialogsMu for all save-dialog editing helpers.
+func (u *mtrUI) cycleSnapshotFormat(delta int) {
+	formats := []string{"txt", "json", "html"}
+	index := 0
+	for i, format := range formats {
+		if format == u.saveDialog.Format {
+			index = i
+		}
+	}
+	old := u.saveDialog.Format
+	u.saveDialog.Format = formats[(index+delta+len(formats))%len(formats)]
+	if filepath.Ext(u.saveDialog.Path) == "."+old {
+		u.saveDialog.Path = strings.TrimSuffix(u.saveDialog.Path, "."+old) + "." + u.saveDialog.Format
+	}
+	u.saveDialog.Error, u.saveDialog.Notice = "", ""
+}
+
+func (u *mtrUI) editSnapshotPath(b byte, paste bool) {
+	e := &u.saveDialog
+	if !paste {
+		switch b {
+		case 8, 127:
+			if len(u.saveUTF8) != 0 {
+				u.saveUTF8 = nil
+			} else if e.Path != "" {
+				_, size := utf8.DecodeLastRuneInString(e.Path)
+				e.Path = e.Path[:len(e.Path)-size]
+			}
+			e.Error, e.Notice = "", ""
+			return
+		case 21:
+			e.Path, e.Error, e.Notice = "", "", ""
+			u.saveUTF8 = nil
+			return
+		}
+	} else if b == '\r' || b == '\n' || b == '\t' {
+		b = ' '
+	}
+	if b < 32 || b == 127 {
+		u.saveUTF8 = nil
+		return
+	}
+	u.saveUTF8 = append(u.saveUTF8, b)
+	for utf8.FullRune(u.saveUTF8) {
+		r, size := utf8.DecodeRune(u.saveUTF8)
+		u.saveUTF8 = u.saveUTF8[size:]
+		if (r == utf8.RuneError && size == 1) || unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			continue
+		}
+		if len(e.Path)+size > mtrSnapshotPathLimit {
+			e.Error = "Path exceeds 4096 bytes"
+			continue
+		}
+		e.Path += string(r)
+		e.Error, e.Notice = "", ""
+	}
+}
+
+func (u *mtrUI) submitSnapshot() {
+	e := &u.saveDialog
+	if u.saveSnapshot == nil {
+		e.Error = "No snapshot available"
+		return
+	}
+	if strings.TrimSpace(e.Path) == "" {
+		e.Error = "Enter a file path"
+		return
+	}
+	if len(u.saveUTF8) != 0 {
+		e.Error = "Incomplete path character"
+		return
+	}
+	if u.snapshotClosed {
+		return
+	}
+	if u.snapshotJobs == nil {
+		u.snapshotJobs = make(chan mtrSnapshotJob, 1)
+		u.snapshotDone = make(chan struct{})
+		go u.runSnapshotSaver()
+	}
+	e.Busy = true
+	e.Error, e.Notice = "", ""
+	u.snapshotError = nil
+	u.snapshotJobs <- mtrSnapshotJob{path: e.Path, format: e.Format, snapshot: u.saveSnapshot}
+}
+
+func (u *mtrUI) runSnapshotSaver() {
+	defer close(u.snapshotDone)
+	write := u.writeSnapshot
+	if write == nil {
+		write = writeMTRSnapshotFile
+	}
+	for job := range u.snapshotJobs {
+		err := write(job.path, job.snapshot, job.format)
+		u.dialogsMu.Lock()
+		u.saveDialog.Busy = false
+		if err != nil {
+			u.snapshotError = fmt.Errorf("save report: %w", err)
+			u.saveDialog.Error = mtrSnapshotSaveError(err)
+		} else {
+			u.saveDialog.Notice = "Saved: " + job.path
+		}
+		u.dialogsMu.Unlock()
+		u.requestRedraw()
+	}
+}
+
+func mtrSnapshotSaveError(err error) string {
+	cause := err
+	var pathError *os.PathError
+	if errors.As(err, &pathError) {
+		cause = pathError.Err
+	}
+	switch {
+	case errors.Is(err, os.ErrExist):
+		cause = os.ErrExist
+	case errors.Is(err, os.ErrPermission):
+		cause = os.ErrPermission
+	}
+	return "save report: " + cause.Error()
+}
+
+func (u *mtrUI) closeSnapshotSaver() error {
+	u.dialogsMu.Lock()
+	if !u.snapshotClosed {
+		u.snapshotClosed = true
+		if u.snapshotJobs != nil {
+			close(u.snapshotJobs)
+		}
+	}
+	done := u.snapshotDone
+	u.dialogsMu.Unlock()
+	if done != nil {
+		<-done
+	}
+	u.dialogsMu.Lock()
+	defer u.dialogsMu.Unlock()
+	err := u.snapshotError
+	u.snapshotError = nil
+	return err
+}
+
+func writeMTRSnapshotFile(path string, snapshot *printer.MTRSnapshot, format string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	original, statErr := f.Stat()
+	writeErr := printer.WriteMTRSnapshot(f, *snapshot, format)
+	closeErr := f.Close()
+	if err = errors.Join(writeErr, closeErr); err != nil {
+		// Remove only the incomplete file this task created, never a replacement.
+		current, lstatErr := os.Lstat(path)
+		if statErr == nil && lstatErr == nil && os.SameFile(original, current) {
+			_ = os.Remove(path)
+		}
+	}
+	return err
+}

--- a/cmd/mtr_snapshot_ui_test.go
+++ b/cmd/mtr_snapshot_ui_test.go
@@ -1,0 +1,294 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/printer"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func snapshotForDialog() *printer.MTRSnapshot {
+	return &printer.MTRSnapshot{
+		CapturedAt: time.Date(2026, 9, 12, 10, 11, 12, 0, time.UTC),
+		Source:     "live", State: "running",
+		Session: &mtrsession.Session{Target: "example.com", Protocol: "icmp"},
+		Stats:   []trace.MTRHopStat{{TTL: 1, IP: "192.0.2.1", Snt: 3}},
+	}
+}
+
+func waitSnapshotResult(t *testing.T, u *mtrUI) printer.MTRSaveDialog {
+	t.Helper()
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+	for {
+		dialog, _ := u.dialogSnapshot()
+		if !dialog.Busy {
+			return dialog
+		}
+		select {
+		case <-u.redraw:
+		case <-timer.C:
+			t.Fatal("snapshot writer did not finish")
+		}
+	}
+}
+
+func TestMTRSnapshotDialogCapturesOnceAndEditsUnicode(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	var captures int
+	u.captureSnapshot = func() *printer.MTRSnapshot { captures++; return snapshotForDialog() }
+	u.paused.Store(true)
+	u.historyMode.Store(true)
+	var keys mtrKeyInput
+	feedMTRKeys(u, &keys, "s")
+	dialog, _ := u.dialogSnapshot()
+	if !dialog.Active || dialog.Format != "txt" || !strings.HasSuffix(dialog.Path, ".txt") || dialog.CapturedAt != snapshotForDialog().CapturedAt {
+		t.Fatal(dialog)
+	}
+	feedMTRKeys(u, &keys, "\x1b[C")
+	dialog, _ = u.dialogSnapshot()
+	if dialog.Format != "json" || !strings.HasSuffix(dialog.Path, ".json") {
+		t.Fatal(dialog)
+	}
+	feedMTRKeys(u, &keys, "\x1bOD ") // SS3 left, then Space returns to JSON.
+	feedMTRKeys(u, &keys, "\t\x15报告😀\x7f结果.json")
+	dialog, _ = u.dialogSnapshot()
+	if dialog.Path != "报告结果.json" || !utf8.ValidString(dialog.Path) || dialog.Format != "json" {
+		t.Fatal(dialog)
+	}
+	feedMTRKeys(u, &keys, "qprynedgo?s")
+	if captures != 1 || !u.IsPaused() || !u.IsHistoryMode() || u.ConsumeRestartRequest() || u.CurrentDisplayMode() != 0 || u.CurrentNameMode() != 0 || u.IsMPLSDisabled() {
+		t.Fatal("path editing leaked shortcuts")
+	}
+	feedMTRKeys(u, &keys, "\x1b")
+	keys.expireEscape(u, time.Now().Add(mtrEscapeDelay))
+	dialog, _ = u.dialogSnapshot()
+	if dialog.Active || !u.IsPaused() || !u.IsHistoryMode() {
+		t.Fatal("cancel changed the view or pause state")
+	}
+}
+
+func TestMTRSnapshotPasteCannotSubmitOrTriggerHelp(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	u.captureSnapshot = snapshotForDialog
+	var keys mtrKeyInput
+	feedMTRKeys(u, &keys, "s\t\x15")
+	for _, part := range []string{"\x1b[2", "00~", "中文?\r\n\t", "qpsoe\u202e.json", "\x1b[20", "1~"} {
+		feedMTRKeys(u, &keys, part)
+	}
+	dialog, help := u.dialogSnapshot()
+	if dialog.Path != "中文?   qpsoe.json" || dialog.Busy || !dialog.Active || help.Active {
+		t.Fatalf("paste escaped path editor: %+v %+v", dialog, help)
+	}
+	feedMTRKeys(u, &keys, "\x15"+strings.Repeat("中", 1400))
+	dialog, _ = u.dialogSnapshot()
+	if len(dialog.Path) > mtrSnapshotPathLimit || !utf8.ValidString(dialog.Path) || dialog.Error == "" {
+		t.Fatal("path limit split a rune or was not enforced")
+	}
+	var cancelled bool
+	u.cancel = func() { cancelled = true }
+	feedMTRKeys(u, &keys, "\x1b[200~\x03")
+	if !cancelled {
+		t.Fatal("paste swallowed Ctrl-C")
+	}
+}
+
+func TestMTRHelpIsolationScrollingAndQuit(t *testing.T) {
+	for _, replay := range []bool{false, true} {
+		u := newMTRUI(nil, 0)
+		if replay {
+			u.replay = &mtrReplayControls{commands: make(chan mtrReplayCommand, 1)}
+		}
+		u.paused.Store(true)
+		u.historyMode.Store(true)
+		var keys mtrKeyInput
+		feedMTRKeys(u, &keys, "?p ryneodgsj")
+		_, help := u.dialogSnapshot()
+		if !help.Active || !u.IsPaused() || !u.IsHistoryMode() || u.ConsumeRestartRequest() || u.CurrentDisplayMode() != 0 || u.CurrentNameMode() != 0 || u.IsMPLSDisabled() {
+			t.Fatal("help changed session state")
+		}
+		if replay && len(u.replay.commands) > 0 {
+			t.Fatal("help sent replay command")
+		}
+		feedMTRKeys(u, &keys, "\x1b[B")
+		_, help = u.dialogSnapshot()
+		if replay && help.Offset == 0 {
+			t.Fatal("down arrow did not scroll")
+		}
+		feedMTRKeys(u, &keys, "\x1bOA")
+		_, help = u.dialogSnapshot()
+		if help.Offset != 0 {
+			t.Fatal("SS3 up did not scroll back")
+		}
+		feedMTRKeys(u, &keys, "\x1b[200~?q\x1b[201~")
+		if !u.isMTRHelpActive() {
+			t.Fatal("pasted help shortcut was activated")
+		}
+		feedMTRKeys(u, &keys, "?")
+		if u.isMTRHelpActive() || !u.IsPaused() {
+			t.Fatal("help did not close cleanly")
+		}
+		feedMTRKeys(u, &keys, "?\x1b")
+		keys.expireEscape(u, time.Now().Add(mtrEscapeDelay))
+		if u.isMTRHelpActive() {
+			t.Fatal("Esc did not close help")
+		}
+		var cancelled bool
+		u.cancel = func() { cancelled = true }
+		feedMTRKeys(u, &keys, "?")
+		if !keys.feed(u, 'q', time.Now()) || !cancelled {
+			t.Fatal("q did not quit from help")
+		}
+	}
+}
+
+func TestMTRSnapshotWriterIsSingleAndDoesNotBlockInput(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	u.captureSnapshot = snapshotForDialog
+	started := make(chan mtrSnapshotJob, 1)
+	release := make(chan struct{})
+	var writes atomic.Int32
+	u.writeSnapshot = func(path string, s *printer.MTRSnapshot, format string) error {
+		writes.Add(1)
+		started <- mtrSnapshotJob{path: path, snapshot: s, format: format}
+		<-release
+		return errors.New("test write failure")
+	}
+	var keys mtrKeyInput
+	feedMTRKeys(u, &keys, "s\r")
+	select {
+	case job := <-started:
+		if job.snapshot.Stats[0].Snt != 3 || job.format != "txt" {
+			t.Fatal(job)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("writer did not start")
+	}
+	feedMTRKeys(u, &keys, "\r\r\x1b")
+	keys.expireEscape(u, time.Now().Add(mtrEscapeDelay))
+	feedMTRKeys(u, &keys, "p?r")
+	if !u.IsPaused() || !u.isMTRHelpActive() || u.ConsumeRestartRequest() || writes.Load() != 1 {
+		t.Fatal("slow write blocked input or allowed concurrent writes")
+	}
+	closed := make(chan error, 1)
+	go func() { closed <- u.closeSnapshotSaver() }()
+	select {
+	case <-closed:
+		t.Fatal("shutdown did not wait for in-flight write")
+	default:
+	}
+	close(release)
+	select {
+	case err := <-closed:
+		if err == nil || !strings.Contains(err.Error(), "test write failure") {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not finish")
+	}
+	if err := u.closeSnapshotSaver(); err != nil {
+		t.Fatal("repeated shutdown duplicated error", err)
+	}
+}
+
+func TestMTRSnapshotSaveFailureRetryAndFileSafety(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	u.captureSnapshot = snapshotForDialog
+	t.Cleanup(func() { _ = u.closeSnapshotSaver() })
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.txt")
+	if err := os.WriteFile(existing, []byte("original"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var keys mtrKeyInput
+	feedMTRKeys(u, &keys, "s\t\x15"+existing+"\r")
+	dialog := waitSnapshotResult(t, u)
+	if !dialog.Active || dialog.Error == "" {
+		t.Fatal(dialog)
+	}
+	if content, _ := os.ReadFile(existing); string(content) != "original" {
+		t.Fatal("overwrote existing file")
+	}
+	path := filepath.Join(dir, "报告.txt")
+	feedMTRKeys(u, &keys, "\x15"+path+"\r")
+	dialog = waitSnapshotResult(t, u)
+	if !strings.HasPrefix(dialog.Notice, "Saved: ") || dialog.Error != "" {
+		t.Fatal(dialog)
+	}
+	info, err := os.Stat(path)
+	if err != nil || (runtime.GOOS != "windows" && info.Mode().Perm() != 0600) {
+		t.Fatal(info, err)
+	}
+	if err := u.closeSnapshotSaver(); err != nil {
+		t.Fatal("already rendered failure leaked to exit", err)
+	}
+	if runtime.GOOS != "windows" {
+		link := filepath.Join(dir, "link.txt")
+		if err := os.Symlink(existing, link); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeMTRSnapshotFile(link, snapshotForDialog(), "txt"); !errors.Is(err, os.ErrExist) {
+			t.Fatalf("symlink not refused: %v", err)
+		}
+	}
+	partial := filepath.Join(dir, "bad.format")
+	if err := writeMTRSnapshotFile(partial, snapshotForDialog(), "invalid"); err == nil {
+		t.Fatal("unsupported format accepted")
+	}
+	if _, err := os.Stat(partial); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("incomplete output was retained: %v", err)
+	}
+}
+
+func TestMTRSnapshotNoDataAndReadOnlyDirectory(t *testing.T) {
+	u := newMTRUI(nil, 0)
+	var keys mtrKeyInput
+	feedMTRKeys(u, &keys, "s\r")
+	dialog, _ := u.dialogSnapshot()
+	if dialog.Error != "No snapshot available" || dialog.Busy {
+		t.Fatal(dialog)
+	}
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		return
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+	if err := writeMTRSnapshotFile(filepath.Join(dir, "report.txt"), snapshotForDialog(), "txt"); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("read-only directory: %v", err)
+	}
+}
+
+func TestMTRSnapshotSaveErrorKeepsCauseVisibleAndExitDetails(t *testing.T) {
+	path := filepath.Join(strings.Repeat("long-directory/", 10), "report.txt")
+	for _, cause := range []error{os.ErrExist, os.ErrPermission} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			u := newMTRUI(nil, 0)
+			u.captureSnapshot = snapshotForDialog
+			u.writeSnapshot = func(string, *printer.MTRSnapshot, string) error {
+				return &os.PathError{Op: "open", Path: path, Err: cause}
+			}
+			var keys mtrKeyInput
+			feedMTRKeys(u, &keys, "s\r")
+			exitErr := u.closeSnapshotSaver()
+			if !errors.Is(exitErr, cause) || !strings.Contains(exitErr.Error(), path) {
+				t.Fatalf("exit lost full error: %v", exitErr)
+			}
+			dialog, _ := u.dialogSnapshot()
+			if dialog.Error != "save report: "+cause.Error() || len(dialog.Error) > 40 {
+				t.Fatalf("40-column dialog lost cause: %q", dialog.Error)
+			}
+		})
+	}
+}

--- a/cmd/mtr_snapshot_ui_test.go
+++ b/cmd/mtr_snapshot_ui_test.go
@@ -42,6 +42,44 @@ func waitSnapshotResult(t *testing.T, u *mtrUI) printer.MTRSaveDialog {
 	}
 }
 
+func TestMTRReplaySnapshotUsesImmediateControlState(t *testing.T) {
+	for _, tc := range []struct {
+		name, keys, published, want string
+		paused                      bool
+	}{
+		{"pause and save", "ps", "running", "paused", false},
+		{"resume and save", " S", "paused", "running", true},
+		{"restart and save", "rs", "running", "paused", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := snapshotForDialog()
+			snapshot.Source, snapshot.State = "replay", tc.published
+			snapshot.ElapsedNS = int64(time.Second)
+			snapshot.Replay = &printer.MTRSnapshotReplay{CursorNS: int64(time.Second), DurationNS: int64(5 * time.Second), RecordingComplete: true, RecordedPaused: true}
+			var store mtrSnapshotStore
+			store.publish(*snapshot)
+			u := newMTRUI(nil, 0)
+			u.paused.Store(tc.paused)
+			u.replay = &mtrReplayControls{commands: make(chan mtrReplayCommand, 1)}
+			u.captureSnapshot = func() *printer.MTRSnapshot { return captureMTRDisplay(&store, u, false) }
+			var keys mtrKeyInput
+			// No replay-loop render runs between these bytes of one input read.
+			feedMTRKeys(u, &keys, tc.keys)
+			frozen := u.saveSnapshot
+			if frozen == nil || frozen.State != tc.want {
+				t.Fatalf("saved state = %+v, want %s", frozen, tc.want)
+			}
+			if frozen.CapturedAt != snapshot.CapturedAt || frozen.ElapsedNS != snapshot.ElapsedNS || *frozen.Replay != *snapshot.Replay || frozen.Stats[0].Snt != snapshot.Stats[0].Snt {
+				t.Fatal("control capture changed the committed replay data")
+			}
+			u.paused.Store(!u.IsPaused())
+			if frozen.State != tc.want || store.capture().State != tc.published {
+				t.Fatal("control capture changed the published or frozen state")
+			}
+		})
+	}
+}
+
 func TestMTRSnapshotDialogCapturesOnceAndEditsUnicode(t *testing.T) {
 	u := newMTRUI(nil, 0)
 	var captures int

--- a/cmd/mtr_snapshot_ui_test.go
+++ b/cmd/mtr_snapshot_ui_test.go
@@ -105,6 +105,7 @@ func TestMTRSnapshotPasteCannotSubmitOrTriggerHelp(t *testing.T) {
 func TestMTRHelpIsolationScrollingAndQuit(t *testing.T) {
 	for _, replay := range []bool{false, true} {
 		u := newMTRUI(nil, 0)
+		u.terminalSize = func() (int, int) { return 80, 24 }
 		if replay {
 			u.replay = &mtrReplayControls{commands: make(chan mtrReplayCommand, 1)}
 		}

--- a/cmd/mtr_ui.go
+++ b/cmd/mtr_ui.go
@@ -30,6 +30,7 @@ type mtrUI struct {
 	snapshotClosed  bool
 	snapshotError   error
 	writeSnapshot   func(string, *printer.MTRSnapshot, string) error
+	terminalSize    func() (int, int)
 	columnsMu       sync.Mutex
 	columns         []printer.MTRColumn
 	columnEditor    printer.MTRColumnEditor

--- a/cmd/mtr_ui.go
+++ b/cmd/mtr_ui.go
@@ -19,22 +19,33 @@ import (
 
 // mtrUI 管理终端交互状态：备份屏幕、raw mode、按键处理。
 type mtrUI struct {
-	columnsMu    sync.Mutex
-	columns      []printer.MTRColumn
-	columnEditor printer.MTRColumnEditor
-	replayEditor printer.MTRReplayEditor
-	replay       *mtrReplayControls
-	redraw       chan struct{}
-	isTTY        bool
-	oldState     *term.State // raw mode 之前的终端状态
-	paused       atomic.Bool
-	restartReq   atomic.Bool
-	displayMode  atomic.Int32 // 显示模式 0-4
-	nameMode     atomic.Int32 // Host 基础显示 0=PTR/IP, 1=IP only
-	disableMPLS  atomic.Bool
-	historyMode  atomic.Bool
-	chartMode    atomic.Int32 // history chart mode 0-2
-	cancel       context.CancelFunc
+	dialogsMu       sync.Mutex
+	saveDialog      printer.MTRSaveDialog
+	helpDialog      printer.MTRHelpDialog
+	captureSnapshot func() *printer.MTRSnapshot
+	saveSnapshot    *printer.MTRSnapshot
+	saveUTF8        []byte
+	snapshotJobs    chan mtrSnapshotJob
+	snapshotDone    chan struct{}
+	snapshotClosed  bool
+	snapshotError   error
+	writeSnapshot   func(string, *printer.MTRSnapshot, string) error
+	columnsMu       sync.Mutex
+	columns         []printer.MTRColumn
+	columnEditor    printer.MTRColumnEditor
+	replayEditor    printer.MTRReplayEditor
+	replay          *mtrReplayControls
+	redraw          chan struct{}
+	isTTY           bool
+	oldState        *term.State // raw mode 之前的终端状态
+	paused          atomic.Bool
+	restartReq      atomic.Bool
+	displayMode     atomic.Int32 // 显示模式 0-4
+	nameMode        atomic.Int32 // Host 基础显示 0=PTR/IP, 1=IP only
+	disableMPLS     atomic.Bool
+	historyMode     atomic.Bool
+	chartMode       atomic.Int32 // history chart mode 0-2
+	cancel          context.CancelFunc
 }
 
 // newMTRUI 创建 TUI 控制器。cancel 是用于退出 MTR 的 context cancel 函数。
@@ -234,15 +245,22 @@ const (
 	mtrActionColumns
 	mtrActionReplayJump
 	mtrActionPasteStart
+	mtrActionSave
+	mtrActionHelp
+	mtrActionUp
+	mtrActionDown
+	mtrActionLeft
+	mtrActionRight
 )
 
 // mtrInputParser 是一个字节级状态机，能区分普通按键与
 // CSI/SS3/OSC/鼠标/焦点等转义序列，对后者整体吞掉。
 type mtrInputParser struct {
-	state      mtrParserState
-	trackPaste bool
-	csi        string
-	csiN       int // CSI 体内已读字节数（用于限制吞掉长度）
+	state       mtrParserState
+	trackPaste  bool
+	trackArrows bool
+	csi         string
+	csiN        int // CSI 体内已读字节数（用于限制吞掉长度）
 }
 
 type mtrParserState int
@@ -271,7 +289,7 @@ func (p *mtrInputParser) Feed(b byte) mtrInputAction {
 	case mtrStateCSI:
 		return p.feedCSI(b)
 	case mtrStateSS3:
-		return p.feedSS3()
+		return p.feedSS3(b)
 	case mtrStateOSC:
 		return p.feedOSC(b)
 	case mtrStateX10Mouse:
@@ -310,12 +328,16 @@ func (p *mtrInputParser) feedEsc(b byte) mtrInputAction {
 
 func (p *mtrInputParser) feedCSI(b byte) mtrInputAction {
 	p.csiN++
-	if p.trackPaste && len(p.csi) < mtrParserMaxCSI {
+	if (p.trackPaste || p.trackArrows) && len(p.csi) < mtrParserMaxCSI {
 		p.csi += string(b)
 	}
 	if p.trackPaste && p.csi == "200~" {
 		p.state = mtrStateGround
 		return mtrActionPasteStart
+	}
+	if p.trackArrows && len(p.csi) == 1 && b >= 'A' && b <= 'D' {
+		p.state = mtrStateGround
+		return mapMTRArrow(b)
 	}
 	switch {
 	case b == 'M':
@@ -333,8 +355,25 @@ func (p *mtrInputParser) feedCSI(b byte) mtrInputAction {
 	return mtrActionNone
 }
 
-func (p *mtrInputParser) feedSS3() mtrInputAction {
+func (p *mtrInputParser) feedSS3(b byte) mtrInputAction {
 	p.state = mtrStateGround
+	if p.trackArrows {
+		return mapMTRArrow(b)
+	}
+	return mtrActionNone
+}
+
+func mapMTRArrow(b byte) mtrInputAction {
+	switch b {
+	case 'A':
+		return mtrActionUp
+	case 'B':
+		return mtrActionDown
+	case 'C':
+		return mtrActionRight
+	case 'D':
+		return mtrActionLeft
+	}
 	return mtrActionNone
 }
 
@@ -388,6 +427,10 @@ func mapKeyToAction(b byte) mtrInputAction {
 		return mtrActionColumns
 	case 'j', 'J':
 		return mtrActionReplayJump
+	case 's', 'S':
+		return mtrActionSave
+	case '?':
+		return mtrActionHelp
 	default:
 		return mtrActionNone
 	}
@@ -490,6 +533,10 @@ func ParseMTRKey(b byte) string {
 		return "history_chart"
 	case 'o', 'O':
 		return "columns"
+	case 's', 'S':
+		return "save"
+	case '?':
+		return "help"
 	default:
 		return ""
 	}

--- a/cmd/mtr_ui_fuzz_test.go
+++ b/cmd/mtr_ui_fuzz_test.go
@@ -6,6 +6,8 @@ const fuzzMTRInputMaxBytes = 4096
 
 func FuzzMTRInputParser(f *testing.F) {
 	f.Add([]byte("p rynedgq"))
+	f.Add([]byte("oOjJsS?"))
+	f.Add([]byte("\x1b[A\x1b[B\x1b[C\x1b[D\x1bOA\x1bOB\x1bOC\x1bOD"))
 	f.Add([]byte{0x1b, '[', '2', '0', '0', '~', 0x1b, ']', '0', ';', 'x', 0x07})
 	f.Add([]byte{0x1b, '[', 'M', 0x20, 0x30, 0x30, 0x1b, 'O', 'P'})
 
@@ -14,18 +16,20 @@ func FuzzMTRInputParser(f *testing.F) {
 			data = data[:fuzzMTRInputMaxBytes]
 		}
 
-		var parser mtrInputParser
-		for _, b := range data {
-			action := parser.Feed(b)
-			if action < mtrActionNone || action > mtrActionPasteStart {
-				t.Fatalf("action = %d, outside known range", action)
+		for _, tracking := range []bool{false, true} {
+			parser := mtrInputParser{trackPaste: tracking, trackArrows: tracking}
+			for _, b := range data {
+				action := parser.Feed(b)
+				if action < mtrActionNone || action > mtrActionRight {
+					t.Fatalf("action = %d, outside known range", action)
+				}
 			}
-		}
-		if parser.state < mtrStateGround || parser.state > mtrStateSGRMouse {
-			t.Fatalf("state = %d, outside known range", parser.state)
-		}
-		if parser.csiN < 0 || parser.csiN > mtrParserMaxCSI+1 {
-			t.Fatalf("CSI byte count = %d, want 0..%d", parser.csiN, mtrParserMaxCSI+1)
+			if parser.state < mtrStateGround || parser.state > mtrStateSGRMouse {
+				t.Fatalf("state = %d, outside known range", parser.state)
+			}
+			if parser.csiN < 0 || parser.csiN > mtrParserMaxCSI+1 {
+				t.Fatalf("CSI byte count = %d, want 0..%d", parser.csiN, mtrParserMaxCSI+1)
+			}
 		}
 	})
 }

--- a/cmd/testdata/fuzz/FuzzMTRInputParser/c55748bfe67e7962
+++ b/cmd/testdata/fuzz/FuzzMTRInputParser/c55748bfe67e7962
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("s")

--- a/cmd/trace_exit_test.go
+++ b/cmd/trace_exit_test.go
@@ -45,7 +45,7 @@ func TestTraceRunErrorProcess(t *testing.T) {
 		}
 		maybeRunMTRMode(effectiveMTRModes{mtr: true, report: true}, trace.ICMPTrace,
 			trace.Config{SrcAddr: "127.0.0.1", DstIP: net.IPv4(127, 0, 0, 1)}, true, 1, false, 0,
-			"127.0.0.1", "disable-geoip", false, 0)
+			"127.0.0.1", "disable-geoip", false, 0, mtrTUIOptions{})
 	case "canceled":
 		exitOnTraceRunError(context.Canceled)
 	case "success":

--- a/docs/mtr-session.md
+++ b/docs/mtr-session.md
@@ -122,6 +122,7 @@ Replay accepts presentation options, not a target or probe configuration.
 | `--show-ips` | Display PTR and IP together |
 | `-g`, `--language` | Display `cn` or `en` using recorded metadata |
 | `-C`, `--no-color` | Disable TUI colors; text reports already have no ANSI |
+| `--no-mtr-summary` | Suppress the text summary after leaving the replay TUI; no effect on non-TTY/report/JSON output |
 
 Omitted host mode, PTR/IP display, columns and language inherit the recording's
 initial settings; MPLS display also starts from the recorded setting. Live column
@@ -138,6 +139,18 @@ TTY opens paused at the last valid position. Space plays at original speed;
 at EOF it starts from the beginning. `p` pauses playback, `r` rewinds and pauses,
 `q` quits. Recorded probe pause and current playback pause are separate states.
 Host, MPLS, columns and the existing three history charts remain available.
+
+`s/S` saves the current cumulative statistics as a `txt`, `json`, or standalone
+`html` [snapshot report](mtr-snapshot.md). The report includes the current
+playback position and display settings, without historical probe events. Saving
+does not change playback or recorded pause state and never overwrites a file.
+Tab switches save fields, Left/Right or Space selects a format, Enter saves,
+and Esc cancels.
+
+`?` opens complete help. Up/Down scroll, `?` or Esc closes help, and `q` or Ctrl-C
+exits. Help does not change playback state. Leaving the TUI restores the terminal
+and prints a plain-text summary at the current position by default; use
+`--no-mtr-summary` to suppress it.
 
 `j/J` opens elapsed-time input, prefilled with the current position, and pauses.
 Use `HH:MM:SS[.mmm]`, with hours allowed beyond 23. Enter seeks and stays paused;

--- a/docs/mtr-snapshot.md
+++ b/docs/mtr-snapshot.md
@@ -1,0 +1,84 @@
+# MTR snapshot reports v1
+
+All three builds can save a report from a live or replay MTR TUI. Press `s/S`
+to open the save dialog. Tab switches between path and format; Left/Right or
+Space changes the selected format. Enter saves and Esc cancels.
+
+## Saved reports
+
+| Format | Content |
+| --- | --- |
+| `txt` | Plain-text session information and cumulative statistics using the current columns and Host/MPLS display |
+| `json` | One `mtr_snapshot` document with session, state, and statistics |
+| `html` | Standalone report using the current columns and Host/MPLS display, viewable without a running NextTrace service |
+
+Opening the save dialog freezes the current cumulative statistics, including
+the reset generation, current display settings and available metadata. Replay reports
+describe the current playback position. Reports do not contain historical probe
+events and cannot be opened by `--mtr-replay`; use `--mtr-record` to retain a
+session's events.
+
+Saving creates a new file and never overwrites an existing file. It does not
+pause probing/playback, reset counters, or change the current display. A save
+error is displayed in the dialog, leaving the session running.
+
+## JSON contract
+
+The file contains one UTF-8 JSON object followed by a newline. Consumers should
+check both `type` and `schema_version` and tolerate additional v1 fields.
+This contract is separate from [live MTR JSON](mtr-json.md) and the
+[offline replay document](mtr-session.md#offline-json-fields).
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | `1` |
+| `type` | `"mtr_snapshot"` |
+| `session` | Session version, target, resolved IP, protocol, start time, effective parameters, source information and current `display` settings |
+| `source` | `"live"` or `"replay"` |
+| `captured_at` | Time the snapshot was captured |
+| `elapsed_ns` | Elapsed session position, in nanoseconds |
+| `generation` | Reset generation for the captured statistics |
+| `state` | `"running"` or `"paused"`; live exit summaries use `"completed"`, `"interrupted"`, or `"error"` |
+| `path_end` | Current path conclusion, or `null` when no conclusion is available |
+| `stats` | Current cumulative `MTRHopStat` rows; an empty result is `[]` |
+
+`session.display` describes the captured display rather than only the settings
+at session startup. Column names use the existing `--mtr-columns` CSV names,
+including repeated `space` entries. Column selection controls report
+presentation; JSON statistics retain all metric fields.
+
+Replay snapshots additionally include a `replay` object:
+
+| Field | Meaning |
+| --- | --- |
+| `cursor_ns` | Current playback position in nanoseconds |
+| `duration_ns` | Available recording duration in nanoseconds |
+| `recording_complete` | Whether the recording has a valid end record |
+| `recorded_paused` | Recorded probe-pause state at the current position |
+
+`recorded_paused` is independent of whether playback is paused. The captured
+statistics describe accepted probe results through the current position;
+in-flight probes are not added as losses. Reset generations, responder ordering,
+missing metadata and zero RTTs retain the existing aggregation rules. Metric
+units and definitions match [MTR JSON statistics](mtr-json.md#final-report).
+`path_end` describes reachability separately from session completion.
+
+## Exit summary
+
+Live and replay TUI sessions restore the terminal and print a plain-text
+summary on exit by default. The replay summary uses the current position.
+
+```sh
+nexttrace --mtr --no-mtr-summary example.com
+nexttrace --mtr-replay session.jsonl --no-mtr-summary
+```
+
+`--no-mtr-summary` suppresses this summary and does not select MTR. Traditional
+traceroute, MTR report, RAW, JSON, and non-TTY output keep their own formats.
+Standalone modes retain their own accepted options.
+
+## Complete help
+
+Press `?` in a live or replay TUI to open complete help. Up/Down scroll the
+help, `?` or Esc closes it, and `q` or Ctrl-C exits. Opening or scrolling help
+does not pause or reset the session.

--- a/printer/mtr_dialog.go
+++ b/printer/mtr_dialog.go
@@ -1,0 +1,165 @@
+package printer
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// Dialog values are immutable frame state supplied by the input controller.
+type MTRSaveDialog struct {
+	Active, Busy  bool
+	Format, Path  string
+	Error, Notice string
+	CapturedAt    time.Time
+	Field         int // 0 = format, 1 = path
+}
+
+type MTRHelpDialog struct {
+	Active bool
+	Offset int
+}
+
+func mtrDialogText(text string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			return -1
+		}
+		return r
+	}, text)
+}
+
+func renderMTRSaveDialog(b *strings.Builder, dialog MTRSaveDialog, width, height int) {
+	remaining := max(0, height-1)
+	line := func(text string) {
+		if remaining > 0 {
+			tuiLine(b, "%s", truncateByDisplayWidth(mtrDialogText(text), width))
+			remaining--
+		}
+	}
+	line("Save report")
+	format := "  Format: " + dialog.Format
+	if dialog.Field == 0 {
+		format = "> Format: " + dialog.Format
+	}
+	line(format)
+	prefix := "  Path: "
+	if dialog.Field == 1 {
+		prefix = "> Path: "
+	}
+	if width <= displayWidth(prefix)+1 {
+		prefix = ">"
+	}
+	path := mtrDialogText(dialog.Path)
+	available := max(0, width-displayWidth(prefix)-1)
+	runes := []rune(path)
+	start, used := len(runes), 0
+	for start > 0 {
+		columns := runewidth.RuneWidth(runes[start-1])
+		if used+columns > available {
+			break
+		}
+		used += columns
+		start--
+	}
+	path = string(runes[start:])
+	line(prefix + path + "_")
+	switch {
+	case dialog.Busy:
+		line("Saving...")
+	case dialog.Error != "":
+		line(dialog.Error)
+	case dialog.Notice != "":
+		line(dialog.Notice)
+	}
+	// Keep primary controls available before optional metadata on short screens.
+	line("Enter: save  Esc: close")
+	line("Tab: field  Left/Right/Space: format")
+	line("Backspace: delete  Ctrl-U: clear")
+	line("Ctrl-C: quit")
+	if !dialog.CapturedAt.IsZero() {
+		line("Captured: " + dialog.CapturedAt.Format("2006-01-02T15:04:05.000Z07:00"))
+	}
+}
+
+func mtrHelpEntries(replay bool) []string {
+	entries := []string{
+		"q/Q, Ctrl-C: quit",
+		"s/S: save current report",
+		"?: open or close this help",
+		"Up/Down: scroll help",
+		"Esc: close help or editor",
+		"p/P: pause probing",
+		"Space: resume probing",
+		"r/R: reset statistics",
+	}
+	if replay {
+		entries[5] = "p/P: pause playback"
+		entries[6] = "Space: play recording"
+		entries[7] = "r/R: rewind and pause"
+		entries = append(entries, "j/J: go to HH:MM:SS[.mmm]")
+	}
+	return append(entries,
+		"y/Y: cycle IP/PTR, ASN, City, Owner, Full",
+		"n/N: toggle PTR/IP or IP only",
+		"e/E: toggle MPLS labels",
+		"d/D: toggle history view",
+		"g/G: cycle charts in history view",
+		"o/O: edit statistics columns",
+		"Fields: Enter applies; Space adds a gap",
+		"Save: Tab switches format and path",
+		"Save format: Left/Right/Space cycles",
+		"Save: Enter writes; existing files stay intact",
+		"Editors: Backspace deletes; Ctrl-U clears",
+		"Editors: pasted newlines never submit",
+		"Editors: Ctrl-C quits the session",
+	)
+}
+
+func mtrHelpLines(replay bool, width int) []string {
+	width = max(1, width)
+	var lines []string
+	for _, entry := range mtrHelpEntries(replay) {
+		var line strings.Builder
+		columns := 0
+		for _, r := range entry {
+			w := runewidth.RuneWidth(r)
+			if columns+w > width && line.Len() > 0 {
+				lines = append(lines, line.String())
+				line.Reset()
+				columns = 0
+			}
+			line.WriteRune(r)
+			columns += w
+		}
+		lines = append(lines, line.String())
+	}
+	return lines
+}
+
+func MTRHelpMaxOffset(replay bool, width, height int) int {
+	return max(0, len(mtrHelpLines(replay, width))-max(1, height-3))
+}
+
+func renderMTRHelpDialog(b *strings.Builder, dialog MTRHelpDialog, replay bool, width, height int) {
+	remaining := max(0, height-1)
+	if remaining == 0 {
+		return
+	}
+	tuiLine(b, "%s", truncateByDisplayWidth("Keyboard shortcuts", width))
+	remaining--
+	if remaining == 0 {
+		return
+	}
+	lines := mtrHelpLines(replay, width)
+	count := max(0, remaining-1)
+	offset := min(max(0, dialog.Offset), max(0, len(lines)-count))
+	for _, line := range lines[offset:min(len(lines), offset+count)] {
+		tuiLine(b, "%s", line)
+	}
+	footer := fmt.Sprintf("?:close Esc:close Up/Down (%d/%d)", offset+1, len(lines))
+	tuiLine(b, "%s", truncateByDisplayWidth(footer, width))
+}

--- a/printer/mtr_dialog_test.go
+++ b/printer/mtr_dialog_test.go
@@ -1,0 +1,89 @@
+package printer
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+func TestMTRDialogsFitNarrowAndShortTerminals(t *testing.T) {
+	for _, width := range []int{1, 8, 24, 40, 80, 120} {
+		for _, height := range []int{2, 5, 10, 24} {
+			for _, save := range []bool{false, true} {
+				header := MTRTUIHeader{}
+				if save {
+					header.SaveDialog = MTRSaveDialog{Active: true, Format: "json", Path: strings.Repeat("中文目录/", 200) + "报告.json", Error: "write failed\x1b[31m", CapturedAt: time.Now()}
+				} else {
+					header.HelpDialog = MTRHelpDialog{Active: true, Offset: 1}
+					header.Replay = &MTRReplayStatus{}
+				}
+				var frame strings.Builder
+				mtrTUIRenderWithSize(&frame, header, nil, width, height)
+				text := strings.TrimPrefix(frame.String(), "\x1b[H\x1b[2J")
+				if !utf8.ValidString(text) || strings.Contains(text, "\x1b") {
+					t.Fatalf("invalid or unsafe dialog: %q", text)
+				}
+				lines := strings.Split(strings.TrimSuffix(text, "\r\n"), "\r\n")
+				if len(lines) > height-1 {
+					t.Fatalf("height %d: %d lines", height, len(lines))
+				}
+				for _, line := range lines {
+					if displayWidth(line) > width {
+						t.Fatalf("width %d: %q", width, line)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestMTRHelpContainsModeSpecificKeysAndScrolls(t *testing.T) {
+	for _, replay := range []bool{false, true} {
+		all := strings.Join(mtrHelpLines(replay, 120), "\n")
+		for _, key := range []string{"q/Q", "Ctrl-C", "s/S", "?", "p/P", "Space", "r/R", "y/Y", "n/N", "e/E", "d/D", "g/G", "o/O", "Tab", "Enter", "Esc", "Backspace", "Ctrl-U"} {
+			if !strings.Contains(all, key) {
+				t.Fatalf("missing %s", key)
+			}
+		}
+		if strings.Contains(all, "j/J") != replay || strings.Contains(all, "pause probing") == replay {
+			t.Fatal("incorrect help mode", all)
+		}
+		var start, end strings.Builder
+		renderMTRHelpDialog(&start, MTRHelpDialog{Active: true}, replay, 40, 8)
+		renderMTRHelpDialog(&end, MTRHelpDialog{Active: true, Offset: MTRHelpMaxOffset(replay, 40, 8)}, replay, 40, 8)
+		if start.String() == end.String() || !strings.Contains(end.String(), "Ctrl-C quits the session") {
+			t.Fatal("cannot scroll to final help entry", end.String())
+		}
+	}
+}
+
+func TestMTRHelpHintSurvivesNarrowTerminals(t *testing.T) {
+	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
+	for _, width := range []int{1, 8, 24, 40, 80, 120, 200} {
+		for _, replay := range []bool{false, true} {
+			header := MTRTUIHeader{}
+			if replay {
+				header.Replay = &MTRReplayStatus{}
+			}
+			line := ansi.ReplaceAllString(buildMTRTUIControlsLine(header, width), "")
+			if !strings.Contains(line, "?") || displayWidth(line) > width {
+				t.Fatalf("width %d replay %v: %q", width, replay, line)
+			}
+		}
+	}
+}
+
+func TestMTRSaveErrorCauseRemainsVisibleAt40Columns(t *testing.T) {
+	for _, cause := range []string{"file already exists", "permission denied"} {
+		var frame strings.Builder
+		renderMTRSaveDialog(&frame, MTRSaveDialog{
+			Active: true, Format: "txt", Path: strings.Repeat("long-directory/", 10) + "report.txt",
+			Error: "save report: " + cause,
+		}, 40, 10)
+		if !strings.Contains(frame.String(), "save report: "+cause+"\r\n") {
+			t.Fatalf("error cause was truncated: %q", frame.String())
+		}
+	}
+}

--- a/printer/mtr_replay.go
+++ b/printer/mtr_replay.go
@@ -48,7 +48,7 @@ func buildMTRReplayControls(header MTRTUIHeader, width int) string {
 	if r.RecordedPaused {
 		status += " Probe-paused"
 	}
-	return truncateByDisplayWidth(status+"  Q:quit J:time Space:play P:pause R:rewind D:history G:chart O:cols Y:display N:host E:mpls", width)
+	return truncateByDisplayWidth("?:help S:save "+status+"  Q:quit J:time Space:play P:pause R:rewind D:history G:chart O:cols Y:display N:host E:mpls", width)
 }
 
 func renderMTRReplayEditor(b *strings.Builder, editor MTRReplayEditor, width int) {

--- a/printer/mtr_snapshot.go
+++ b/printer/mtr_snapshot.go
@@ -1,0 +1,260 @@
+package printer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+// MTRSnapshot is a point-in-time report, not an event recording or a completed
+// session. Callers own the snapshot and must not change it while writing.
+type MTRSnapshot struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Type          string              `json:"type"`
+	Source        string              `json:"source"`
+	CapturedAt    time.Time           `json:"captured_at"`
+	ElapsedNS     int64               `json:"elapsed_ns"`
+	Generation    uint64              `json:"generation"`
+	State         string              `json:"state"`
+	Session       *mtrsession.Session `json:"session"`
+	PathEnd       *trace.StopReason   `json:"path_end"`
+	Stats         []trace.MTRHopStat  `json:"stats"`
+	Replay        *MTRSnapshotReplay  `json:"replay,omitempty"`
+}
+
+// MTRSnapshotReplay describes the committed replay position in a snapshot.
+type MTRSnapshotReplay struct {
+	CursorNS          int64 `json:"cursor_ns"`
+	DurationNS        int64 `json:"duration_ns"`
+	RecordingComplete bool  `json:"recording_complete"`
+	RecordedPaused    bool  `json:"recorded_paused"`
+}
+
+// MTRColumnNames serializes the current display selection using CLI column names.
+func MTRColumnNames(columns []MTRColumn) string {
+	names := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if int(column) < len(mtrColumnDefinitions) {
+			names = append(names, mtrColumnDefinitions[column].name)
+		}
+	}
+	return strings.Join(names, ",")
+}
+
+// WriteMTRSnapshot writes an immutable report as txt, json or self-contained html.
+// JSON preserves all recorded values; human-readable formats clean display text.
+func WriteMTRSnapshot(w io.Writer, s MTRSnapshot, format string) error {
+	var content []byte
+	var err error
+	switch format {
+	case "json":
+		s.SchemaVersion, s.Type = 1, "mtr_snapshot"
+		if s.Stats == nil {
+			s.Stats = []trace.MTRHopStat{}
+		}
+		content, err = json.MarshalIndent(s, "", "  ")
+		if err == nil {
+			content = append(content, '\n')
+		}
+	case "txt", "html":
+		var report mtrSnapshotReport
+		report, err = buildMTRSnapshotReport(s)
+		if err != nil {
+			break
+		}
+		var b bytes.Buffer
+		if format == "html" {
+			err = mtrSnapshotHTML.Execute(&b, report)
+		} else {
+			b.WriteString("NextTrace MTR snapshot\n")
+			for _, field := range report.Metadata {
+				fmt.Fprintf(&b, "%s: %s\n", field.Label, field.Value)
+			}
+			b.WriteByte('\n')
+			b.WriteString(report.Table)
+		}
+		content = b.Bytes()
+	default:
+		return fmt.Errorf("unknown MTR snapshot format %q", format)
+	}
+	if err != nil {
+		return err
+	}
+	n, err := w.Write(content)
+	if err == nil && n != len(content) {
+		err = io.ErrShortWrite
+	}
+	return err
+}
+
+// DefaultMTRSnapshotFilename returns a portable filename in the current directory.
+func DefaultMTRSnapshotFilename(s MTRSnapshot, format string) string {
+	target := "target"
+	if s.Session != nil && s.Session.Target != "" {
+		target = s.Session.Target
+	}
+	var name strings.Builder
+	for _, r := range target {
+		if name.Len() >= 80 {
+			break
+		}
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '.' || r == '-' || r == '_' {
+			name.WriteRune(r)
+		} else {
+			name.WriteByte('-')
+		}
+	}
+	target = strings.Trim(name.String(), ".-_")
+	if target == "" {
+		target = "target"
+	}
+	if format != "json" && format != "html" {
+		format = "txt"
+	}
+	return fmt.Sprintf("nexttrace-%s-%s.%s", target, s.CapturedAt.Format("20060102-150405.000000000"), format)
+}
+
+type mtrSnapshotField struct{ Label, Value string }
+
+type mtrSnapshotReport struct {
+	Metadata []mtrSnapshotField
+	Table    string
+}
+
+func buildMTRSnapshotReport(s MTRSnapshot) (mtrSnapshotReport, error) {
+	display := mtrsession.DisplayParameters{ShowMPLS: true}
+	lang := "cn"
+	if s.Session != nil {
+		display = s.Session.Display
+		if s.Session.EffectiveParameters != nil {
+			lang = s.Session.EffectiveParameters.Language
+		}
+	}
+	columns := DefaultMTRColumns()
+	if display.Columns != "" {
+		var err error
+		columns, err = ParseMTRColumns(display.Columns, false)
+		if err != nil {
+			return mtrSnapshotReport{}, err
+		}
+	}
+	hosts := make([]mtrHostParts, len(s.Stats))
+	asnWidth := 0
+	for i, stat := range s.Stats {
+		parts := buildTUIHostParts(stat, display.HostMode, display.HostNameMode, lang, display.ShowIPs)
+		parts.asn = mtrSnapshotText(parts.asn)
+		parts.base = mtrSnapshotText(parts.base)
+		for j := range parts.extras {
+			parts.extras[j] = mtrSnapshotText(parts.extras[j])
+		}
+		hosts[i] = parts
+		asnWidth = max(asnWidth, displayWidth(parts.asn))
+	}
+	rows := make([]string, len(s.Stats))
+	hostWidth, hopWidth := len("Host"), len("Hop")
+	for i, stat := range s.Stats {
+		rows[i] = mtrSnapshotText(appendMTRResponseMarker(formatTUIHost(hosts[i], asnWidth), stat))
+		hostWidth = max(hostWidth, displayWidth(rows[i]))
+		hopWidth = max(hopWidth, len(fmt.Sprint(stat.TTL)))
+	}
+	widths := mtrColumnWidths(columns, s.Stats)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s  %s  %s\n", padLeft("Hop", hopWidth), padRight("Host", hostWidth), mtrSelectedMetrics(columns, widths, nil, false))
+	previousTTL := -1
+	for i, stat := range s.Stats {
+		hop := ""
+		if stat.TTL != previousTTL {
+			hop = fmt.Sprint(stat.TTL)
+		}
+		fmt.Fprintf(&b, "%s  %s  %s\n", padLeft(hop, hopWidth), padRight(rows[i], hostWidth), mtrSelectedMetrics(columns, widths, &stat, false))
+		previousTTL = stat.TTL
+		if display.ShowMPLS {
+			for _, mpls := range stat.MPLS {
+				fmt.Fprintf(&b, "%s  %s\n", strings.Repeat(" ", hopWidth), mtrSnapshotText(mpls))
+			}
+		}
+	}
+	if len(s.Stats) == 0 {
+		b.WriteString("No probe statistics.\n")
+	}
+	return mtrSnapshotReport{Metadata: mtrSnapshotMetadata(s), Table: b.String()}, nil
+}
+
+func mtrSnapshotMetadata(s MTRSnapshot) []mtrSnapshotField {
+	var fields []mtrSnapshotField
+	add := func(label, value string) {
+		value = mtrSnapshotText(value)
+		if value == "" {
+			value = "-"
+		}
+		fields = append(fields, mtrSnapshotField{label, value})
+	}
+	if session := s.Session; session != nil {
+		add("Target", session.Target)
+		if session.ResolvedIP != session.Target {
+			add("Resolved IP", session.ResolvedIP)
+		}
+		add("Protocol", session.Protocol)
+		source := session.SourceIP
+		if source == "" && session.EffectiveParameters != nil {
+			source = session.EffectiveParameters.SourceAddress
+		}
+		if session.SourceHost != "" && session.SourceHost != source {
+			if source != "" {
+				source = session.SourceHost + " (" + source + ")"
+			} else {
+				source = session.SourceHost
+			}
+		}
+		add("Source", source)
+		if !session.StartedAt.IsZero() {
+			add("Started", session.StartedAt.Format(time.RFC3339Nano))
+		}
+	}
+	add("Captured", s.CapturedAt.Format(time.RFC3339Nano))
+	if s.Replay == nil {
+		add("Elapsed", FormatMTRReplayTime(time.Duration(s.ElapsedNS)))
+	}
+	add("Mode", s.Source)
+	add("State", s.State)
+	add("Generation", fmt.Sprint(s.Generation))
+	if s.PathEnd != nil {
+		add("Path", strings.TrimPrefix(FormatTraceStopReason(s.PathEnd), "Trace Stopped: "))
+	}
+	if r := s.Replay; r != nil {
+		add("Replay", FormatMTRReplayTime(time.Duration(r.CursorNS))+" / "+FormatMTRReplayTime(time.Duration(r.DurationNS)))
+		complete := "Incomplete"
+		if r.RecordingComplete {
+			complete = "Complete"
+		}
+		add("Recording", complete)
+		add("Recorded paused", fmt.Sprint(r.RecordedPaused))
+	}
+	return fields
+}
+
+// Control and format characters are never emitted into human-readable fields.
+// Keep the original strings untouched for JSON and event recordings.
+func mtrSnapshotText(value string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			return ' '
+		}
+		return r
+	}, value)
+}
+
+var mtrSnapshotHTML = template.Must(template.New("mtr-snapshot").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NextTrace MTR snapshot</title>
+<style>body{margin:2rem;font:16px system-ui,sans-serif;color:#17212b;background:#fff}h1{font-size:1.5rem}dl{display:grid;grid-template-columns:max-content 1fr;gap:.35rem 1rem}dt{font-weight:600}dd{margin:0;overflow-wrap:anywhere}pre{overflow-x:auto;padding:1rem;background:#f4f6f8;font:14px/1.6 ui-monospace,monospace;white-space:pre}@media print{body{margin:0}pre{overflow:visible;font-size:9px}}</style>
+</head><body><h1>NextTrace MTR snapshot</h1><dl>{{range .Metadata}}<dt>{{.Label}}</dt><dd>{{.Value}}</dd>{{end}}</dl><pre>{{.Table}}</pre></body></html>
+`))

--- a/printer/mtr_snapshot_test.go
+++ b/printer/mtr_snapshot_test.go
@@ -1,0 +1,266 @@
+package printer
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/nxtrace/NTrace-core/internal/mtrsession"
+	"github.com/nxtrace/NTrace-core/ipgeo"
+	"github.com/nxtrace/NTrace-core/trace"
+)
+
+func snapshotReportFixture() MTRSnapshot {
+	return MTRSnapshot{
+		Source: "live", State: "running", CapturedAt: time.Date(2026, 9, 12, 8, 9, 10, 11, time.FixedZone("test", 8*3600)),
+		ElapsedNS: int64(3 * time.Second), Generation: 2,
+		Session: &mtrsession.Session{
+			Target: "目标.example", ResolvedIP: "203.0.113.1", Protocol: "ICMP", SourceHost: "test-host", SourceIP: "192.0.2.2",
+			EffectiveParameters: &mtrsession.Parameters{Language: "cn"},
+			Display:             mtrsession.DisplayParameters{HostMode: HostModeFull, ShowIPs: true, ShowMPLS: true, Columns: "received,space,space,jint"},
+		},
+		Stats: []trace.MTRHopStat{
+			{TTL: 1, Host: "网关.example", IP: "192.0.2.1", Snt: 8, Received: 7, Dropped: 1, Loss: 12.5, JitterInterarrival: 13.5,
+				Geo: &ipgeo.IPGeoData{Asnumber: "1", Country: "中国", City: "上海", Owner: "运营商"}, MPLS: []string{"[MPLS: Label 123]"}},
+			{TTL: 2, Host: strings.Repeat("very-long-host-", 12) + ".example", IP: "203.0.113.1", Snt: 8, Received: 8,
+				Geo: &ipgeo.IPGeoData{Asnumber: "123456"}},
+			{TTL: 3, Snt: 8, Loss: 100},
+		},
+		PathEnd: &trace.StopReason{Hop: 2, Reason: trace.StopReasonDestination},
+	}
+}
+
+func TestWriteMTRSnapshotTextUsesCurrentDisplayAndFullHosts(t *testing.T) {
+	s := snapshotReportFixture()
+	var out bytes.Buffer
+	if err := WriteMTRSnapshot(&out, s, "txt"); err != nil {
+		t.Fatal(err)
+	}
+	report := out.String()
+	for _, want := range []string{
+		"Target: 目标.example", "Source: test-host (192.0.2.2)", "Protocol: ICMP", "State: running", "Generation: 2",
+		"Elapsed: 00:00:03.000", "Captured: 2026-09-12T08:09:10.000000011+08:00",
+		"Path: Destination Reached at Hop 2", "网关.example (192.0.2.1) 中国 上海 运营商", s.Stats[1].Host,
+		"[MPLS: Label 123]", "Rcv    Jint", "13.50", "(waiting for reply)",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("missing %q in report:\n%s", want, report)
+		}
+	}
+	if strings.Contains(report, "StDev") || strings.Contains(report, "Trace Stopped") {
+		t.Fatalf("snapshot used default columns or claimed the live session stopped:\n%s", report)
+	}
+	lines := strings.Split(report, "\n")
+	var hostStarts []int
+	for _, line := range lines {
+		if at := strings.Index(line, "网关.example"); at >= 0 {
+			hostStarts = append(hostStarts, displayWidth(line[:at]))
+		}
+		if at := strings.Index(line, s.Stats[1].Host); at >= 0 {
+			hostStarts = append(hostStarts, displayWidth(line[:at]))
+		}
+	}
+	if len(hostStarts) != 2 || hostStarts[0] != hostStarts[1] {
+		t.Fatalf("ASN prefixes are not aligned: %v", hostStarts)
+	}
+}
+
+func TestWriteMTRSnapshotHostModesAndMPLSVisibility(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mode     int
+		nameMode int
+		want     string
+		absent   []string
+	}{
+		{"base", HostModeBase, HostNamePTRorIP, "网关.example", []string{"AS1", "上海", "运营商"}},
+		{"asn", HostModeASN, HostNamePTRorIP, "AS1", []string{"上海", "运营商"}},
+		{"city", HostModeCity, HostNamePTRorIP, "上海", []string{"运营商"}},
+		{"owner", HostModeOwner, HostNamePTRorIP, "运营商", []string{"上海"}},
+		{"ip", HostModeBase, HostNameIPOnly, "192.0.2.1", []string{"网关.example", "AS1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := snapshotReportFixture()
+			s.Session.Display.HostMode, s.Session.Display.HostNameMode = tc.mode, tc.nameMode
+			s.Session.Display.ShowMPLS = false
+			var out bytes.Buffer
+			if err := WriteMTRSnapshot(&out, s, "txt"); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), tc.want) {
+				t.Fatalf("missing %q", tc.want)
+			}
+			for _, absent := range append(tc.absent, "[MPLS: Label 123]") {
+				if strings.Contains(out.String(), absent) {
+					t.Errorf("unexpected %q", absent)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteMTRSnapshotJSONContractAndRawValues(t *testing.T) {
+	s := snapshotReportFixture()
+	s.Type, s.SchemaVersion = "end", 999
+	s.Source, s.State = "replay", "paused"
+	s.Replay = &MTRSnapshotReplay{CursorNS: 5, DurationNS: 10, RecordingComplete: false, RecordedPaused: true}
+	s.Stats[0].Host = "原值\x1b\n\u202e<script>"
+	var out bytes.Buffer
+	if err := WriteMTRSnapshot(&out, s, "json"); err != nil {
+		t.Fatal(err)
+	}
+	var decoded MTRSnapshot
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Type != "mtr_snapshot" || decoded.SchemaVersion != 1 {
+		t.Fatalf("unexpected schema: %+v", decoded)
+	}
+	if !reflect.DeepEqual(decoded.Stats, s.Stats) || !reflect.DeepEqual(decoded.Replay, s.Replay) {
+		t.Fatalf("JSON lost statistics or raw values: %s", out.String())
+	}
+	if s.Type != "end" || s.SchemaVersion != 999 {
+		t.Fatal("writing mutated the input")
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, absent := range []string{"end", "ended_at", "end_reason"} {
+		if _, exists := fields[absent]; exists {
+			t.Errorf("snapshot invented %q", absent)
+		}
+	}
+	if !strings.Contains(out.String(), `"jitter_interarrival_ms": 13.5`) || !strings.Contains(out.String(), `"dropped": 1`) {
+		t.Fatal("selected text columns leaked into JSON field selection")
+	}
+}
+
+func TestWriteMTRSnapshotEmptyStatsAndReplayStatus(t *testing.T) {
+	s := snapshotReportFixture()
+	s.Stats = nil
+	s.Replay = &MTRSnapshotReplay{CursorNS: int64(time.Second), DurationNS: int64(10 * time.Second)}
+	var out bytes.Buffer
+	if err := WriteMTRSnapshot(&out, s, "json"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"stats": []`) {
+		t.Fatalf("empty statistics must be an array: %s", out.String())
+	}
+	out.Reset()
+	if err := WriteMTRSnapshot(&out, s, "txt"); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"No probe statistics.", "Replay: 00:00:01.000 / 00:00:10.000", "Recording: Incomplete"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("missing %q: %s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "Elapsed:") {
+		t.Fatal("replay repeats the cursor as elapsed time")
+	}
+	out.Reset()
+	if err := WriteMTRSnapshot(&out, s, "html"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "<dt>Elapsed</dt>") || strings.Count(out.String(), "00:00:01.000") != 1 {
+		t.Fatal("HTML repeats the replay cursor")
+	}
+}
+
+func TestWriteMTRSnapshotEscapesHTMLAndRemovesDisplayControls(t *testing.T) {
+	s := snapshotReportFixture()
+	s.Session.Target = `<script>alert("target")</script>`
+	s.Stats[0].Host = "<img src=x onerror=alert(1)>\r\n\x1b\u202e中文"
+	s.Stats[0].Geo.Owner = "控制\x07运营商"
+	s.Stats[0].MPLS = []string{"标签\x9d\u200e"}
+	for _, format := range []string{"txt", "html"} {
+		var out bytes.Buffer
+		if err := WriteMTRSnapshot(&out, s, format); err != nil {
+			t.Fatal(err)
+		}
+		for _, r := range out.String() {
+			if (unicode.IsControl(r) && r != '\n') || unicode.Is(unicode.Cf, r) {
+				t.Errorf("%s contains control rune %U", format, r)
+			}
+		}
+		if format == "html" {
+			if strings.Contains(out.String(), "<script>") || strings.Contains(out.String(), "<img ") || strings.Contains(out.String(), "<link ") {
+				t.Fatalf("HTML contains unescaped content or external resource: %s", out.String())
+			}
+			if !strings.Contains(out.String(), "&lt;script&gt;") || !strings.Contains(out.String(), "&lt;img ") {
+				t.Fatalf("missing escaped content: %s", out.String())
+			}
+		}
+	}
+	if !strings.Contains(s.Stats[0].Host, "\x1b") || !strings.Contains(s.Stats[0].Geo.Owner, "\x07") {
+		t.Fatal("human report changed source strings")
+	}
+}
+
+type snapshotShortWriter struct{ err error }
+
+func (w snapshotShortWriter) Write(p []byte) (int, error) { return len(p) / 2, w.err }
+
+func TestWriteMTRSnapshotPropagatesWriteAndEncodingErrors(t *testing.T) {
+	s := snapshotReportFixture()
+	failure := errors.New("disk full")
+	for _, format := range []string{"txt", "json", "html"} {
+		if err := WriteMTRSnapshot(snapshotShortWriter{}, s, format); !errors.Is(err, io.ErrShortWrite) {
+			t.Errorf("%s short write: %v", format, err)
+		}
+		if err := WriteMTRSnapshot(snapshotShortWriter{failure}, s, format); !errors.Is(err, failure) {
+			t.Errorf("%s writer error: %v", format, err)
+		}
+	}
+	var out bytes.Buffer
+	if err := WriteMTRSnapshot(&out, s, "csv"); err == nil || out.Len() != 0 {
+		t.Fatal("unknown format should fail before writing")
+	}
+	s.Session.Display.Columns = "unknown"
+	if err := WriteMTRSnapshot(&out, s, "txt"); err == nil || out.Len() != 0 {
+		t.Fatal("invalid columns should fail before writing")
+	}
+	s.Stats[0].Avg = math.NaN()
+	if err := WriteMTRSnapshot(&out, s, "json"); err == nil || out.Len() != 0 {
+		t.Fatal("invalid JSON data should fail before writing")
+	}
+}
+
+func TestDefaultMTRSnapshotFilenameIsPortableAndUnicodeSafe(t *testing.T) {
+	s := snapshotReportFixture()
+	for _, target := range []string{"目标.example", "CON", "../../etc/passwd", "2001:db8::1%en0", "?<>|*\"\\/\x00\u202e", strings.Repeat("界", 200)} {
+		s.Session.Target = target
+		name := DefaultMTRSnapshotFilename(s, "html")
+		if !utf8.ValidString(name) || filepath.Base(name) != name || len(name) >= 255 || strings.ContainsAny(name, "<>:\"/\\|?*\x00\u202e") {
+			t.Errorf("unsafe filename %q from target %q", name, target)
+		}
+		if !strings.HasSuffix(name, "-20260912-080910.000000011.html") {
+			t.Errorf("wrong time or extension: %q", name)
+		}
+	}
+	if got := DefaultMTRSnapshotFilename(MTRSnapshot{}, "unknown"); !strings.HasSuffix(got, ".txt") {
+		t.Errorf("default format: %q", got)
+	}
+}
+
+func TestMTRSnapshotColumnNamesRoundTrip(t *testing.T) {
+	columns := []MTRColumn{MTRColumnJitterInterarrival, MTRColumnSpace, MTRColumnSpace, MTRColumnReceived}
+	names := MTRColumnNames(columns)
+	if names != "jint,space,space,received" {
+		t.Fatalf("unexpected names: %q", names)
+	}
+	parsed, err := ParseMTRColumns(names, false)
+	if err != nil || !reflect.DeepEqual(parsed, columns) {
+		t.Fatalf("columns did not round-trip: %v, %v", parsed, err)
+	}
+}

--- a/printer/mtr_tui.go
+++ b/printer/mtr_tui.go
@@ -55,6 +55,8 @@ type MTRTUIHeader struct {
 	Now              time.Time // zero uses the live clock
 	Replay           *MTRReplayStatus
 	ReplayEditor     MTRReplayEditor
+	SaveDialog       MTRSaveDialog
+	HelpDialog       MTRHelpDialog
 }
 
 // ---------------------------------------------------------------------------
@@ -386,6 +388,16 @@ func mtrTUIRenderWithSize(w io.Writer, header MTRTUIHeader, stats []trace.MTRHop
 	var b strings.Builder
 
 	writeMTRTUIFramePrefix(&b)
+	if header.SaveDialog.Active {
+		renderMTRSaveDialog(&b, header.SaveDialog, lo.termWidth, termHeight)
+		_, _ = fmt.Fprint(w, b.String())
+		return
+	}
+	if header.HelpDialog.Active {
+		renderMTRHelpDialog(&b, header.HelpDialog, header.Replay != nil, lo.termWidth, termHeight)
+		_, _ = fmt.Fprint(w, b.String())
+		return
+	}
 	if header.ReplayEditor.Active {
 		tuiLine(&b, "%s", buildMTRTUITitleLine(header, lo.termWidth))
 		renderMTRReplayEditor(&b, header.ReplayEditor, lo.termWidth)
@@ -401,6 +413,11 @@ func mtrTUIRenderWithSize(w io.Writer, header MTRTUIHeader, stats []trace.MTRHop
 		renderMTRSelectedHeader(&b, header, lo.termWidth)
 	} else {
 		renderMTRTUIHeader(&b, header, lo.termWidth)
+	}
+	if header.SaveDialog.Error != "" {
+		tuiLine(&b, "%s", truncateByDisplayWidth(mtrDialogText(header.SaveDialog.Error), lo.termWidth))
+	} else if header.SaveDialog.Notice != "" {
+		tuiLine(&b, "%s", truncateByDisplayWidth(mtrDialogText(header.SaveDialog.Notice), lo.termWidth))
 	}
 	if header.HistoryMode {
 		renderMTRTUIHistory(&b, header, stats, lo.termWidth)
@@ -533,10 +550,13 @@ func resolveMTRTUIDestinationLabel(header MTRTUIHeader) string {
 }
 
 func buildMTRTUIControlsLine(header MTRTUIHeader, termWidth int) string {
+	if termWidth > 0 && termWidth < len("?:help") {
+		return "?"
+	}
 	if header.Replay != nil {
 		return buildMTRReplayControls(header, termWidth)
 	}
-	const keysPrefix = "Keys:  "
+	const keysPrefix = ""
 	items := buildMTRTUIKeyItems(header, mtrTUIKeyHiColor)
 	plainItems := buildMTRTUIKeyItems(header, fmt.Sprint)
 	keyLine := strings.Join(items, "  ")
@@ -548,7 +568,15 @@ func buildMTRTUIControlsLine(header MTRTUIHeader, termWidth int) string {
 		pad = termWidth - displayWidth(keysPrefix) - displayWidth(strings.Join(plainItems, " ")) - len("["+statusText+"]")
 	}
 	if pad < 2 {
-		compact := "O:cols Q:quit"
+		// Preserve the existing mode indicators on medium-width terminals;
+		// the help entry also exposes saving when its separate hint cannot fit.
+		items = append(items[:1], items[2:]...)
+		plainItems = append(plainItems[:1], plainItems[2:]...)
+		keyLine = strings.Join(items, " ")
+		pad = termWidth - displayWidth(strings.Join(plainItems, " ")) - len("["+statusText+"]")
+	}
+	if pad < 2 {
+		compact := "?:help S:save O:cols Q:quit"
 		if header.HistoryMode {
 			compact += " G-chart(" + mtrTUIHistoryChartLabel(header.HistoryChartMode) + ")"
 		}
@@ -559,6 +587,8 @@ func buildMTRTUIControlsLine(header MTRTUIHeader, termWidth int) string {
 
 func buildMTRTUIKeyItems(header MTRTUIHeader, highlight func(...any) string) []string {
 	items := []string{
+		highlight("?") + "-help",
+		highlight("S") + "-save",
 		highlight("Q") + "uit",
 		highlight("O") + "-columns",
 		highlight("P") + "ause",
@@ -1109,6 +1139,21 @@ func MTRTUIPrinter(target, domain, targetIP, version string, startTime time.Time
 	srcHost, srcIP, lang string, apiInfo func() string, showIPs bool,
 	isPaused func() bool, displayMode func() int, nameMode func() int, isMPLSDisabled func() bool,
 	isHistoryMode func() bool, historyChartMode func() int, historySnapshot func(time.Time) []MTRHistoryTTL, columnState ...func() ([]MTRColumn, MTRColumnEditor)) func(iteration int, stats []trace.MTRHopStat) {
+	var columns func() ([]MTRColumn, MTRColumnEditor)
+	if len(columnState) > 0 {
+		columns = columnState[0]
+	}
+	return MTRTUIPrinterWithDialogs(target, domain, targetIP, version, startTime, srcHost, srcIP, lang, apiInfo, showIPs,
+		isPaused, displayMode, nameMode, isMPLSDisabled, isHistoryMode, historyChartMode, historySnapshot, columns, nil)
+}
+
+// MTRTUIPrinterWithDialogs extends the existing printer without changing its
+// optional column-state API for callers that do not expose interactive dialogs.
+func MTRTUIPrinterWithDialogs(target, domain, targetIP, version string, startTime time.Time,
+	srcHost, srcIP, lang string, apiInfo func() string, showIPs bool,
+	isPaused func() bool, displayMode func() int, nameMode func() int, isMPLSDisabled func() bool,
+	isHistoryMode func() bool, historyChartMode func() int, historySnapshot func(time.Time) []MTRHistoryTTL,
+	columnState func() ([]MTRColumn, MTRColumnEditor), dialogState func() (MTRSaveDialog, MTRHelpDialog)) func(iteration int, stats []trace.MTRHopStat) {
 	var apiInfoMu sync.Mutex
 	var cachedAPIInfo string
 	var cachedAPIInfoAt time.Time
@@ -1161,12 +1206,19 @@ func MTRTUIPrinter(target, domain, targetIP, version string, startTime time.Time
 		headerAPIInfo := getAPIInfo()
 		var columns []MTRColumn
 		var editor MTRColumnEditor
-		if len(columnState) > 0 && columnState[0] != nil {
-			columns, editor = columnState[0]()
+		if columnState != nil {
+			columns, editor = columnState()
+		}
+		var saveDialog MTRSaveDialog
+		var helpDialog MTRHelpDialog
+		if dialogState != nil {
+			saveDialog, helpDialog = dialogState()
 		}
 		MTRTUIRender(os.Stdout, MTRTUIHeader{
 			Columns:          columns,
 			ColumnEditor:     editor,
+			SaveDialog:       saveDialog,
+			HelpDialog:       helpDialog,
 			Target:           target,
 			StartTime:        startTime,
 			Status:           status,

--- a/scripts/test_mtr_snapshot_pty.py
+++ b/scripts/test_mtr_snapshot_pty.py
@@ -35,11 +35,32 @@ def resize(terminal, width, height):
 
 
 def recording_probes(path):
-    with open(path, encoding="utf-8") as source:
+    with open(path, "rb") as source:
         lines = source.readlines()
     # The writer publishes complete lines; a concurrent read may see its tail.
-    records = [json.loads(line) for line in lines if line.endswith("\n")]
+    records = [json.loads(line.decode("utf-8"))
+               for line in lines if line.endswith(b"\n")]
     return sum(record["type"] == "probe" for record in records)
+
+
+def check_recording_tail(directory):
+    path = os.path.join(directory, "reader-tail.jsonl")
+    prefix = b'{"type":"probe"}\n'
+    tail = (json.dumps({"type": "probe", "host": "中文😀"},
+                       ensure_ascii=False) + "\n").encode("utf-8")
+    # Exercise every byte boundary, including cuts inside multibyte characters.
+    for end in range(len(tail) + 1):
+        with open(path, "wb") as output:
+            output.write(prefix + tail[:end])
+        assert recording_probes(path) == 1 + int(end == len(tail)), end
+    with open(path, "wb") as output:
+        output.write(prefix + b'{"type":"probe","host":"\xff"}\n')
+    try:
+        recording_probes(path)
+    except UnicodeDecodeError:
+        pass
+    else:
+        raise AssertionError("Invalid UTF-8 in a complete record was ignored")
 
 
 def check_help(terminal, recording=None):
@@ -282,6 +303,7 @@ def main(binary):
                    "--timeout", "100", "--no-color", "--language", "en", "127.0.0.1"]
     try:
         with tempfile.TemporaryDirectory(prefix="mtr-snapshot-pty-") as directory:
+            check_recording_tail(directory)
             recording = os.path.join(directory, "session.jsonl")
             online = Terminal([binary] + mode + ["--mtr-record", recording] + probe_flags, log)
             try:

--- a/scripts/test_mtr_snapshot_pty.py
+++ b/scripts/test_mtr_snapshot_pty.py
@@ -1,0 +1,337 @@
+"""Exercise MTR snapshot saving, help and exit summaries on PTY/ConPTY.
+
+Usage: python3 scripts/test_mtr_snapshot_pty.py /path/to/nexttrace
+Accepts full, tiny and ntr builds. Only live loopback probes are sent; replay
+uses the recording created by this run. Windows needs pywinpty==3.0.5.
+Linux CI runs under sudo for ICMP socket access.
+"""
+
+import json
+import os
+import platform
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+from test_mtr_session_pty import Terminal, replay_time
+
+if os.name != "nt":
+    import fcntl
+    import termios
+
+
+SUMMARY = "NextTrace MTR snapshot"
+
+
+def resize(terminal, width, height):
+    if terminal.windows:
+        terminal.process.setwinsize(height, width)
+    else:
+        fcntl.ioctl(terminal.slave, termios.TIOCSWINSZ,
+                    struct.pack("HHHH", height, width, 0, 0))
+
+
+def recording_probes(path):
+    with open(path, encoding="utf-8") as source:
+        lines = source.readlines()
+    # The writer publishes complete lines; a concurrent read may see its tail.
+    records = [json.loads(line) for line in lines if line.endswith("\n")]
+    return sum(record["type"] == "probe" for record in records)
+
+
+def check_help(terminal, recording=None):
+    resize(terminal, 100, 10)
+    terminal.send("?")
+    terminal.expect("Keyboard shortcuts")
+    terminal.send("\x1b[B" * 8)
+    terminal.expect("Up/Down (9/")
+    terminal.send("\x1b[A" * 8)
+    terminal.expect("Up/Down (1/")
+    if recording:
+        before = recording_probes(recording)
+        terminal.read(0.6)
+        assert recording_probes(recording) > before, "Help paused live probing"
+    terminal.send("\x1b")
+    terminal.expect("Rcv")
+    terminal.send("?")
+    terminal.expect("Keyboard shortcuts")
+    terminal.send("?")
+    terminal.expect("Rcv")
+    resize(terminal, 150, 32)
+
+
+def save_report(terminal, path, format_name, recording=None, exists=False):
+    terminal.send("s")
+    terminal.expect("Save report")
+    before = None
+    if recording:
+        before = recording_probes(recording)
+        terminal.read(0.6)
+        assert recording_probes(recording) > before, "Save dialog paused live probing"
+    terminal.send({"txt": "", "json": "\x1b[C", "html": "\x1b[D"}[format_name])
+    terminal.send("\t\x15" + path + "\r")
+    if exists:
+        terminal.expect("save report:")
+    else:
+        terminal.expect("Saved:")
+        assert os.path.isfile(path), f"Report was not created: {path}"
+    terminal.send("\x1b")
+    terminal.expect("Rcv")
+    return before
+
+
+def check_snapshot(path, source):
+    with open(path, encoding="utf-8") as report:
+        snapshot = json.load(report)
+    assert snapshot["type"] == "mtr_snapshot", snapshot
+    assert snapshot["schema_version"] == 1, snapshot
+    assert snapshot["source"] == source, snapshot
+    assert snapshot["session"]["display"]["columns"] == "avg,received", snapshot
+    assert snapshot["state"] in ("running", "paused"), snapshot
+    assert snapshot["captured_at"] and snapshot["elapsed_ns"] >= 0, snapshot
+    assert snapshot["generation"] == 0, snapshot
+    assert len(snapshot["stats"]) == 1, snapshot
+    stat = snapshot["stats"][0]
+    assert stat["ip"] == "127.0.0.1" and stat["snt"] > 0, snapshot
+    # A selected two-column table still exports every JSON statistic.
+    for metric in ("loss_percent", "snt", "received", "avg_ms", "last_ms",
+                   "stdev_ms", "dropped", "jitter_interarrival_ms"):
+        assert metric in stat, (metric, snapshot)
+    return snapshot
+
+
+def check_files(paths):
+    with open(paths["txt"], encoding="utf-8") as source:
+        text = source.read()
+    assert text.startswith(SUMMARY + "\n"), text
+    assert "Avg" in text and "Rcv" in text and "127.0.0.1" in text, text
+    assert "Loss%" not in text, "Text report ignored current columns"
+    assert "\x1b" not in text, "Text report contains terminal escapes"
+    with open(paths["html"], encoding="utf-8") as source:
+        html = source.read()
+    assert html.lower().startswith("<!doctype html>"), html
+    assert "Avg" in html and "Rcv" in html and "127.0.0.1" in html, html
+    assert "<script" not in html.lower(), "Standalone report unexpectedly contains a script"
+    assert "\x1b" not in html, "HTML report contains terminal escapes"
+
+
+def quit_with_summary(terminal, enabled, expected_code=0):
+    start = len(terminal.log)
+    terminal.send("q")
+    terminal.expect("\x1b[?1049l", "\x1b[?25h")
+    if terminal.windows:
+        deadline = time.monotonic() + 3
+        while terminal.process.isalive() and time.monotonic() < deadline:
+            terminal.read(0.1)
+        assert not terminal.process.isalive(), "Process did not exit"
+        assert terminal.process.exitstatus == expected_code, terminal.process.exitstatus
+    else:
+        terminal.process.wait(timeout=3)
+        assert terminal.process.returncode == expected_code, terminal.process.returncode
+        assert termios.tcgetattr(terminal.slave) == terminal.original, "Terminal attributes not restored"
+    terminal.read(0.2)
+    output = terminal.log[start:].decode(errors="replace")
+    restored = output.index("\x1b[?1049l")
+    assert SUMMARY not in output[:restored], "Summary printed before terminal restoration"
+    tail = output[restored + len("\x1b[?1049l"):]
+    assert tail.count(SUMMARY) == int(enabled), tail
+    if enabled:
+        assert "127.0.0.1" in tail and "\x1b" not in tail, tail
+
+
+def exercise_session(terminal, directory, source, recording=None):
+    terminal.expect("Rcv", "127.0.0.1")
+    check_help(terminal, recording)
+    terminal.send("o")
+    terminal.expect("Fields:")
+    terminal.send("\x15AR\r")
+    terminal.expect("Avg", "Rcv")
+    paths = {fmt: os.path.join(directory, f"诊断报告 {source}.{fmt}")
+             for fmt in ("txt", "json", "html")}
+    frozen_count = None
+    for fmt, path in paths.items():
+        count = save_report(terminal, path, fmt, recording if fmt == "json" else None)
+        if count is not None:
+            frozen_count = count
+    snapshot = check_snapshot(paths["json"], source)
+    check_files(paths)
+    with open(paths["json"], "rb") as report:
+        original = report.read()
+    save_report(terminal, paths["json"], "json", exists=True)
+    with open(paths["json"], "rb") as report:
+        assert report.read() == original, "Existing report was overwritten"
+    if recording:
+        assert snapshot["stats"][0]["snt"] <= frozen_count, "Saved report changed while the dialog was open"
+        terminal.send("p")
+        terminal.expect("Paused")
+        terminal.read(0.4)
+        paused_path = os.path.join(directory, "暂停报告.json")
+        save_report(terminal, paused_path, "json")
+        paused = check_snapshot(paused_path, "live")
+        assert paused["state"] == "paused", paused
+    return snapshot
+
+
+def read_replay_json(binary, path, expected_code):
+    result = subprocess.run([binary, "--mtr-replay", path, "--json"],
+                            capture_output=True, text=True, timeout=10)
+    assert result.returncode == expected_code, (result.returncode, result.stderr)
+    return json.loads(result.stdout)
+
+
+def write_record_prefix(path, records):
+    with open(path, "x", encoding="utf-8") as output:
+        for record in records:
+            output.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def check_middle_position(binary, terminal, directory, records, final):
+    at = final["duration_ns"] // 2 // 1000000 * 1000000
+    assert 0 < at < final["duration_ns"], final
+    prefix = [record for record in records
+              if record["type"] != "end" and record["elapsed_ns"] <= at]
+    prefix_path = os.path.join(directory, "middle-prefix.jsonl")
+    write_record_prefix(prefix_path, prefix)
+    expected = read_replay_json(binary, prefix_path, 1)
+    assert expected["complete"] is False, expected
+    # There is no --mtr-replay-at flag. The valid event prefix supplies an
+    # independent CLI aggregation oracle; its final event can precede the
+    # requested millisecond cursor, which is asserted separately below.
+    assert expected["cursor_ns"] == prefix[-1]["elapsed_ns"] <= at, expected
+    terminal.send("j")
+    terminal.expect("Go to HH:MM:SS[.mmm]", "Time:")
+    terminal.send("\x15" + replay_time(at) + "\r")
+    terminal.expect("Paused " + replay_time(at) + "/")
+    path = os.path.join(directory, "中间位置.json")
+    save_report(terminal, path, "json")
+    snapshot = check_snapshot(path, "replay")
+    assert snapshot["stats"] == expected["stats"], (snapshot, expected)
+    assert snapshot["stats"][0]["snt"] < final["stats"][0]["snt"], (snapshot, final)
+    assert snapshot["path_end"] == expected["path_end"], (snapshot, expected)
+    assert snapshot["elapsed_ns"] == at, snapshot
+    assert snapshot["replay"] == {
+        "cursor_ns": at, "duration_ns": final["duration_ns"],
+        "recording_complete": True, "recorded_paused": expected["recorded_paused"],
+    }, snapshot
+
+
+def check_incomplete_recording(binary, directory, records, final, log):
+    path = os.path.join(directory, "missing-end.jsonl")
+    assert records[-1]["type"] == "end", records[-1]
+    write_record_prefix(path, records[:-1])
+    expected = read_replay_json(binary, path, 1)
+    assert expected["complete"] is False, expected
+    assert expected["stats"] == final["stats"], (expected, final)
+    terminal = Terminal([binary, "--mtr-replay", path, "--mtr-columns", "avg,received", "--no-color"], log)
+    try:
+        terminal.expect("Rcv", "127.0.0.1", "Incomplete")
+        report_path = os.path.join(directory, "残缺录制.json")
+        save_report(terminal, report_path, "json")
+        snapshot = check_snapshot(report_path, "replay")
+        assert snapshot["stats"] == expected["stats"], (snapshot, expected)
+        assert snapshot["elapsed_ns"] == expected["cursor_ns"], (snapshot, expected)
+        assert snapshot["replay"] == {
+            "cursor_ns": expected["cursor_ns"], "duration_ns": expected["duration_ns"],
+            "recording_complete": False, "recorded_paused": expected["recorded_paused"],
+        }, snapshot
+        quit_with_summary(terminal, True, expected_code=1)
+    finally:
+        terminal.close()
+
+
+def check_non_tty_output(binary, mode, probe_flags):
+    # --mtr-columns belongs to text output, so omit that option for the shared
+    # report/RAW/JSON setup. Captured pipes deliberately select non-TTY output.
+    common = ["-q", "2"] + probe_flags[2:]
+    for output_mode, flags in (("report", ["-r"]), ("raw", ["-r", "--raw"]),
+                               ("json_report", ["-r", "--json"]),
+                               ("json_stream", mode + ["--json"])):
+        for suppress in (False, True):
+            extra = ["--no-mtr-summary"] if suppress else []
+            result = subprocess.run([binary] + flags + extra + common,
+                                    capture_output=True, text=True, timeout=10)
+            assert result.returncode == 0, (output_mode, result.returncode, result.stderr)
+            assert SUMMARY not in result.stdout + result.stderr, (output_mode, result.stdout, result.stderr)
+            assert "\x1b[?1049" not in result.stdout, (output_mode, result.stdout)
+            if output_mode == "report":
+                assert "127.0.0.1" in result.stdout and "Snt" in result.stdout, result.stdout
+            elif output_mode == "raw":
+                rows = [line for line in result.stdout.splitlines() if "|" in line]
+                assert len(rows) == 2 and all(len(line.split("|")) == 12 for line in rows), result.stdout
+            elif output_mode == "json_report":
+                report = json.loads(result.stdout)
+                assert report["stats"][0]["snt"] == 2, report
+            else:
+                events = [json.loads(line) for line in result.stdout.splitlines()]
+                assert events[0]["type"] == "start" and events[-1]["type"] == "end", events
+                assert sum(event["type"] == "probe" for event in events) == 2, events
+
+
+def main(binary):
+    binary = os.path.abspath(binary)
+    log = bytearray()
+    help_result = subprocess.run([binary, "--help"], capture_output=True,
+                                 text=True, timeout=10, check=True)
+    assert "--no-mtr-summary" in help_result.stdout, help_result.stdout
+    mode = ["--mtr"] if re.search(r"^\s+-t\s+--mtr\s", help_result.stdout, re.M) else []
+    probe_flags = ["--mtr-columns", "loss,snt,received,avg", "-d", "disable-geoip",
+                   "-n", "-s", "127.0.0.1", "-m", "1", "-i", "60",
+                   "--timeout", "100", "--no-color", "--language", "en", "127.0.0.1"]
+    try:
+        with tempfile.TemporaryDirectory(prefix="mtr-snapshot-pty-") as directory:
+            recording = os.path.join(directory, "session.jsonl")
+            online = Terminal([binary] + mode + ["--mtr-record", recording] + probe_flags, log)
+            try:
+                exercise_session(online, directory, "live", recording)
+                quit_with_summary(online, True)
+            finally:
+                online.close()
+
+            with open(recording, encoding="utf-8") as source:
+                records = [json.loads(line) for line in source]
+            final = read_replay_json(binary, recording, 0)
+            assert final["complete"] is True, final
+            offline = Terminal([binary, "--mtr-replay", recording, "--no-color"], log)
+            try:
+                snapshot = exercise_session(offline, directory, "replay")
+                assert snapshot["stats"] == final["stats"], (snapshot, final)
+                assert snapshot["elapsed_ns"] == final["cursor_ns"], (snapshot, final)
+                assert snapshot["replay"] == {
+                    "cursor_ns": final["cursor_ns"], "duration_ns": final["duration_ns"],
+                    "recording_complete": True, "recorded_paused": final["recorded_paused"],
+                }, snapshot
+                check_middle_position(binary, offline, directory, records, final)
+                quit_with_summary(offline, True)
+            finally:
+                offline.close()
+
+            for command in ([binary] + mode + ["--no-mtr-summary"] + probe_flags,
+                            [binary, "--mtr-replay", recording, "--no-mtr-summary", "--no-color"]):
+                terminal = Terminal(command, log)
+                try:
+                    terminal.expect("Rcv", "127.0.0.1")
+                    quit_with_summary(terminal, False)
+                finally:
+                    terminal.close()
+            check_incomplete_recording(binary, directory, records, final, log)
+            check_non_tty_output(binary, mode, probe_flags)
+        print(json.dumps({
+            "platform": platform.system(), "binary": os.path.basename(binary), "snapshot_pty": "PASS",
+            "checks": ["live/replay help", "help scrolling", "Esc and ? close help",
+                       "live probes continue in dialogs", "current display columns", "UTF-8 paths",
+                       "txt/json/html reports", "JSON full statistics", "exclusive file creation",
+                       "frozen snapshot", "paused snapshot", "replay statistics/position parity",
+                       "middle seek snapshot/event-prefix parity", "incomplete snapshot and nonzero exit",
+                       "summary after terminal restore", "no-mtr-summary live/replay",
+                       "non-TTY report/RAW/JSON contracts", "terminal restore"],
+        }, indent=2))
+    finally:
+        with open(os.path.join(tempfile.gettempdir(), "mtr-snapshot-pty.log"), "wb") as output:
+            output.write(log)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/skills/nexttrace/references/cli-fallback.md
+++ b/skills/nexttrace/references/cli-fallback.md
@@ -50,6 +50,23 @@ incomplete. Text columns do not change RAW/JSON schemas and cannot accompany
 those output modes. See [JSON](../../../docs/mtr-json.md) and
 [recording/replay](../../../docs/mtr-session.md) for schemas and lifecycle rules.
 
+### TUI reports and help
+
+Live and replay TUI sessions support `s/S` to save the current cumulative
+statistics as `txt`, `json`, or standalone `html`. Tab switches fields;
+Left/Right or Space selects a format, Enter saves, and Esc cancels. Saving
+does not pause/reset probes or playback and never overwrites an existing file.
+The JSON document uses `type: "mtr_snapshot"` and `schema_version: 1`, with the
+current display settings and, for replay, its playback position/completeness.
+It contains no historical events and is not a `--mtr-replay` input.
+See [snapshot reports](../../../docs/mtr-snapshot.md).
+
+The TUI restores the terminal and prints a plain-text summary on exit by
+default. `--no-mtr-summary` suppresses this summary in live and replay TUI,
+does not select MTR, and does not change traditional traceroute or other MTR
+output formats. Standalone modes retain their own accepted options. `?` opens
+complete help; Up/Down scroll, `?` or Esc closes it, and `q` or Ctrl-C exits.
+
 ### Environment check and Linux marks
 
 ```sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * MTR 实时与回放 TUI 支持通过 `s/S` 保存 `txt`、`json` 或 `html` 报告。
  * 新增 `?` 帮助界面，支持滚动查看快捷键说明。
  * 退出 TUI 后默认显示纯文本摘要，可使用 `--no-mtr-summary` 关闭。
  * 保存报告时提供格式切换、路径编辑及文件覆盖保护。

* **文档**
  * 更新中英文 README、会话指南及报告格式说明。

* **测试**
  * 新增实时、回放、PTY/ConPTY 和报告保存相关测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->